### PR TITLE
Add the option to specify extra key/values to the token endpoint

### DIFF
--- a/keycloak/keycloak_openid.py
+++ b/keycloak/keycloak_openid.py
@@ -162,7 +162,7 @@ class KeycloakOpenID:
                        "redirect-uri": redirect_uri}
         return URL_AUTH.format(**params_path)
 
-    def token(self, username="", password="", grant_type=["password"], code="", redirect_uri="", totp=None):
+    def token(self, username="", password="", grant_type=["password"], code="", redirect_uri="", totp=None, **extra):
         """
         The token endpoint is used to obtain tokens. Tokens can either be obtained by
         exchanging an authorization code or by supplying credentials directly depending on
@@ -183,6 +183,8 @@ class KeycloakOpenID:
         payload = {"username": username, "password": password,
                    "client_id": self.client_id, "grant_type": grant_type,
                    "code": code, "redirect_uri": redirect_uri}
+        if payload:
+            payload.update(extra)
 
         if totp:
             payload["totp"] = totp


### PR DESCRIPTION
I tried to use python-keycloak to do a keycloak token exchange but was unable to. Some extra key/values are needed and can't be passed. This PR allows specifying other supported options to the token endpoint.

For example, this works now:
token = keycloak_openid.token(client_id, client_secret, requested_subject=idofuser, audience="target-client-name", grant_type='urn:ietf:params:oauth:grant-type:token-exchange', subject_token=token, requested_token_type='urn:ietf:params:oauth:token-type:access_token', scope='openid')