### PR TITLE
Fix get_subgroups iteration

### DIFF
--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -423,7 +423,10 @@ class KeycloakAdmin:
                 return subgroup
             elif subgroup["subGroups"]:
                 for subgroup in group["subGroups"]:
-                    return self.get_subgroups(subgroup, path)
+                    result = self.get_subgroups(subgroup, path)
+                    if result:
+                        return result
+        # went through the tree without hits
         return None
 
     def get_group_members(self, group_id, **query):


### PR DESCRIPTION
The subgroup iteration would return `None` if the first `subgroup` in `group['subgroups']` didn't contain the path without proceeding to the next subgroup.