### PR TITLE
adds user_realm_name to KeycloakAdmin

### DIFF
--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -45,7 +45,7 @@ class KeycloakAdmin:
 
     PAGE_SIZE = 100
 
-    def __init__(self, server_url, username, password, realm_name='master', client_id='admin-cli', verify=True, client_secret_key=None):
+    def __init__(self, server_url, username, password, realm_name='master', client_id='admin-cli', verify=True, client_secret_key=None, user_realm_name=None):
         """
 
         :param server_url: Keycloak server url
@@ -62,7 +62,7 @@ class KeycloakAdmin:
         self._realm_name = realm_name
 
         # Get token Admin
-        keycloak_openid = KeycloakOpenID(server_url=server_url, client_id=client_id, realm_name=realm_name,
+        keycloak_openid = KeycloakOpenID(server_url=server_url, client_id=client_id, realm_name=user_realm_name or realm_name,
                                          verify=verify, client_secret_key=client_secret_key)
 
         grant_type = ["password"]


### PR DESCRIPTION
fixes #41 

Adds a optional new parameter _user_realm_name_ that takes _realm_name_ value if not defined.
The admin token is retrieved from the given _user_realm_name_ but all methods are run under _realm_name_. This allows to have an admin user in another realm (ie: master).