### PR TITLE
Set session `auth` to trivial function to prevent usage of `.netrc` file

### DIFF
--- a/keycloak/connection.py
+++ b/keycloak/connection.py
@@ -47,6 +47,7 @@ class ConnectionManager(object):
         self._timeout = timeout
         self._verify = verify
         self._s = requests.Session()
+        self._s.auth = lambda x: x  # don't let requests add auth headers
 
         # retry once to reset connection with Keycloak after  tomcat's ConnectionTimeout
         # see https://github.com/marcospereirampj/python-keycloak/issues/36


### PR DESCRIPTION
Sets the session to not add "basic" auth if entry for keycloak host
exists in users `.netrc` (`requests` causes `Authorization: Basic ...`
header to be added if an entry exists in `.netrc` by default)

see: https://requests.readthedocs.io/en/master/api/#requests.Session.auth