### PR TITLE
include data in raw_delete request

### DIFF
--- a/keycloak/connection.py
+++ b/keycloak/connection.py
@@ -198,11 +198,12 @@ class ConnectionManager(object):
             raise KeycloakConnectionError(
                 "Can't connect to server (%s)" % e)
 
-    def raw_delete(self, path, **kwargs):
+    def raw_delete(self, path, data, **kwargs):
         """ Submit delete request to the path.
 
         :arg
             path (str): Path for request.
+            data (dict): Payload for request.
         :return
             Response the request.
         :exception
@@ -211,6 +212,7 @@ class ConnectionManager(object):
         try:
             return self._s.delete(urljoin(self.base_url, path),
                                   params=kwargs,
+                                  data=data,
                                   headers=self.headers,
                                   timeout=self.timeout,
                                   verify=self.verify)


### PR DESCRIPTION
data is missing in raw_delete request: requests with json bodies like in "delete_client_roles_of_user" won't work