### PR TITLE
add MANIFEST.in to package license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
The MIT license requires that the license be distributed with the software when publishing and redistributing it. I've added a MANIFEST.in to make sure that it's in the source distribution of pypi. 