### PR TITLE
Add support for Client Credentials Grant in KeycloakAdmin

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -158,6 +158,14 @@ Main methods::
     #                               realm_name="example_realm",
     #                               verify=True,
     #                               custom_headers={'CustomHeader': 'value'})
+    #
+    # You can also authenticate with client_id and client_secret
+    #keycloak_admin = KeycloakAdmin(server_url="http://localhost:8080/auth/",
+    #                               client_id="example_client",
+    #                               client_secret_key="secret",
+    #                               realm_name="example_realm",
+    #                               verify=True,
+    #                               custom_headers={'CustomHeader': 'value'})
 
     # Add user
     new_user = keycloak_admin.create_user({"email": "example@example.com",

--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -60,7 +60,7 @@ class KeycloakAdmin:
     _custom_headers = None
     _user_realm_name = None
 
-    def __init__(self, server_url, username, password, realm_name='master', client_id='admin-cli', verify=True,
+    def __init__(self, server_url, username=None, password=None, realm_name='master', client_id='admin-cli', verify=True,
                  client_secret_key=None, custom_headers=None, user_realm_name=None, auto_refresh_token=None):
         """
 


### PR DESCRIPTION
Hello

This Pull Request add support for Client Crendentials Grant.

```python
keycloak_admin = KeycloakAdmin(
    server_url="http://localhost:8080/auth/",
    client_id="example_client",
    client_secret_key="secret",
    realm_name="example_realm",
)
```

Cheers
Romain