### PR TITLE
Fix for KeycloakAdmin refresh_token method

### DIFF
--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -1397,7 +1397,13 @@ class KeycloakAdmin:
         try:
             self.token = self.keycloak_openid.refresh_token(refresh_token)
         except KeycloakGetError as e:
-            if e.response_code == 400 and b'Refresh token expired' in e.response_body:
+            # maybe check only if 400?
+            list_errors = [
+                b'Refresh token expired',
+                b'Token is not active',
+                b'Session not active',
+            ]
+            if e.response_code == 400 and any(err in list_errors for err in list_errors):
                 self.get_token()
             else:
                 raise

--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -1403,7 +1403,7 @@ class KeycloakAdmin:
                 b'Token is not active',
                 b'Session not active',
             ]
-            if e.response_code == 400 and any(err in list_errors for err in list_errors):
+            if e.response_code == 400 and any(err in e.response_body for err in list_errors):
                 self.get_token()
             else:
                 raise


### PR DESCRIPTION
Hi!

In my work django project we use KeycloakAdmin class and get errors if user session was killed or expired :)

Steps to reproduce:
1) Create KeycloakAdmin class instance
2) Kill user session in Keycloak
3) Try to call methods.
 
It's may be fix!

Recreate session if: 
+ Token is not active
+ Session not active

