### PR TITLE
Add client-level role operations to groups

### DIFF
--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -1070,7 +1070,7 @@ class KeycloakAdmin:
         :param group_id: id of group
         :param client_id: id of client (not client-id)
         :param roles: roles list or role (use GroupRoleRepresentation)
-        :return Keycloak server response
+        :return Keycloak server response (array RoleRepresentation)
         """
 
         payload = roles if isinstance(roles, list) else [roles]

--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -1032,6 +1032,53 @@ class KeycloakAdmin:
         data_raw = self.raw_get(URL_ADMIN_GET_GROUPS_REALM_ROLES.format(**params_path))
         return raise_error_from_response(data_raw, KeycloakGetError)
 
+    def assign_group_client_roles(self, group_id, client_id, roles):
+        """
+        Assign client roles to a group
+
+        :param group_id: id of group
+        :param client_id: id of client (not client-id)
+        :param roles: roles list or role (use GroupRoleRepresentation)
+        :return Keycloak server response
+        """
+
+        payload = roles if isinstance(roles, list) else [roles]
+        params_path = {"realm-name": self.realm_name, "id": group_id, "client-id": client_id}
+        data_raw = self.raw_post(URL_ADMIN_GROUPS_CLIENT_ROLES.format(**params_path),
+                                 data=json.dumps(payload))
+        return raise_error_from_response(data_raw, KeycloakGetError, expected_code=204)
+
+    def delete_group_client_roles(self, group_id, client_id, roles):
+        """
+        Delete client roles of a group
+
+        :param group_id: id of group
+        :param client_id: id of client (not client-id)
+        :param roles: roles list or role (use GroupRoleRepresentation)
+        :return Keycloak server response
+        """
+
+        payload = roles if isinstance(roles, list) else [roles]
+        params_path = {"realm-name": self.realm_name, "id": group_id, "client-id": client_id}
+        data_raw = self.raw_get(URL_ADMIN_GROUPS_CLIENT_ROLES.format(**params_path))
+        return raise_error_from_response(data_raw, KeycloakGetError)
+
+    def get_group_client_roles(self, group_id, client_id, roles):
+        """
+        Get client roles of a group
+
+        :param group_id: id of group
+        :param client_id: id of client (not client-id)
+        :param roles: roles list or role (use GroupRoleRepresentation)
+        :return Keycloak server response
+        """
+
+        payload = roles if isinstance(roles, list) else [roles]
+        params_path = {"realm-name": self.realm_name, "id": group_id, "client-id": client_id}
+        data_raw = self.raw_delete(URL_ADMIN_GROUPS_CLIENT_ROLES.format(**params_path),
+                                 data=json.dumps(payload))
+        return raise_error_from_response(data_raw, KeycloakGetError, expected_code=204)
+
     def get_client_roles_of_user(self, user_id, client_id):
         """
         Get all client roles for a user.

--- a/keycloak/urls_patterns.py
+++ b/keycloak/urls_patterns.py
@@ -45,6 +45,7 @@ URL_ADMIN_USER_CLIENT_ROLES = "admin/realms/{realm-name}/users/{id}/role-mapping
 URL_ADMIN_USER_REALM_ROLES = "admin/realms/{realm-name}/users/{id}/role-mappings/realm"
 URL_ADMIN_GROUPS_REALM_ROLES = "admin/realms/{realm-name}/groups/{id}/role-mappings/realm"
 URL_ADMIN_GET_GROUPS_REALM_ROLES = "admin/realms/{realm-name}/groups/{id}/role-mappings"
+URL_ADMIN_GROUPS_CLIENT_ROLES = "admin/realms/{realm-name}/groups/{id}/role-mappings/clients/{client-id}"
 URL_ADMIN_USER_CLIENT_ROLES_AVAILABLE = "admin/realms/{realm-name}/users/{id}/role-mappings/clients/{client-id}/available"
 URL_ADMIN_USER_CLIENT_ROLES_COMPOSITE = "admin/realms/{realm-name}/users/{id}/role-mappings/clients/{client-id}/composite"
 URL_ADMIN_USER_GROUP = "admin/realms/{realm-name}/users/{id}/groups/{group-id}"


### PR DESCRIPTION
Currently we can assign only realm roles to groups. This PR adds the ability to assign client-scoped roles to a group.