### PR TITLE
Handle 'Token is not active' error in refresh_token

### DIFF
--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -1397,7 +1397,8 @@ class KeycloakAdmin:
         try:
             self.token = self.keycloak_openid.refresh_token(refresh_token)
         except KeycloakGetError as e:
-            if e.response_code == 400 and b'Refresh token expired' in e.response_body:
+            if e.response_code == 400 and (b'Refresh token expired' in e.response_body or
+                                           b'Token is not active' in e.response_body):
                 self.get_token()
             else:
                 raise


### PR DESCRIPTION
If a token is acquired but not used before it times out, Keycloak will return a 400 response with the message
'Token is not active' (see [TokenVerifier.java](https://github.com/keycloak/keycloak/blob/master/core/src/main/java/org/keycloak/TokenVerifier.java)).

To reproduce the problem, set the SSO Session times in Realm Settings/Tokens for your realm to small numbers, create a `KeycloakAdmin` object and wait until the timeouts expire before using it.

Getting a new token will fix the problem, so this patch changes `refresh_token` to handle this error along with the expired token error.