### PR TITLE
Entitlement API deprecation exception

### DIFF
--- a/keycloak/exceptions.py
+++ b/keycloak/exceptions.py
@@ -53,6 +53,9 @@ class KeycloakOperationError(KeycloakError):
     pass
 
 
+class KeycloakDeprecationError(KeycloakError):
+    pass
+
 class KeycloakGetError(KeycloakOperationError):
     pass
 

--- a/keycloak/keycloak_openid.py
+++ b/keycloak/keycloak_openid.py
@@ -28,7 +28,8 @@ from jose import jwt
 from .authorization import Authorization
 from .connection import ConnectionManager
 from .exceptions import raise_error_from_response, KeycloakGetError, \
-    KeycloakRPTNotFound, KeycloakAuthorizationConfigError, KeycloakInvalidTokenError
+    KeycloakRPTNotFound, KeycloakAuthorizationConfigError, KeycloakInvalidTokenError,
+    KeycloakDeprecationError
 from .urls_patterns import (
     URL_REALM,
     URL_AUTH,
@@ -291,6 +292,9 @@ class KeycloakOpenID:
         self.connection.add_param_headers("Authorization", "Bearer " + token)
         params_path = {"realm-name": self.realm_name, "resource-server-id": resource_server_id}
         data_raw = self.connection.raw_get(URL_ENTITLEMENT.format(**params_path))
+        
+        if data_raw.status_code == 404: 
+            return raise_error_from_response(data_raw, KeycloakDeprecationError)
 
         return raise_error_from_response(data_raw, KeycloakGetError)
 


### PR DESCRIPTION
Add a keycloak deprecation exception to indicate that the entitlement API is not available in all keycloak versions