### PR TITLE
Refactor/remove client id from assign realm roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ realm_roles = keycloak_admin.get_roles()
 # Assign client role to user. Note that BOTH role_name and role_id appear to be required.
 keycloak_admin.assign_client_role(client_id=client_id, user_id=user_id, role_id=role_id, role_name="test")
 
+# Assign realm roles to user
+keycloak_admin.assign_realm_roles(user_id=user_id, roles=realm_roles)
+
+
 # Get all ID Providers
 idps = keycloak_admin.get_idps()
 

--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -909,13 +909,11 @@ class KeycloakAdmin:
         return raise_error_from_response(data_raw, KeycloakGetError, expected_code=201, skip_exists=skip_exists)
 
 
-    def assign_realm_roles(self, user_id, client_id, roles):
+    def assign_realm_roles(self, user_id, roles):
         """
         Assign realm roles to a user
 
-        :param client_id: id of client (not client-id)
         :param user_id: id of user
-        :param client_id: id of client containing role,
         :param roles: roles list or role (use RoleRepresentation)
         :return Keycloak server response
         """


### PR DESCRIPTION
I noticed this method has the kwarg "client_id", which is not actually used anywhere on that method, so I removed it (however, this might be a breaking change?)