### PR TITLE
Read realm roles of user

### DIFF
--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -1015,6 +1015,11 @@ class KeycloakAdmin:
                                  data=json.dumps(payload))
         return raise_error_from_response(data_raw, KeycloakGetError, expected_codes=[204])
 
+    def get_realm_roles_of_user(self, user_id):
+        params_path = {"realm-name": self.realm_name, "id": user_id}
+        data_raw = self.raw_get(URL_ADMIN_USER_REALM_ROLES.format(**params_path))
+        return raise_error_from_response(data_raw, KeycloakGetError)
+
     def assign_group_realm_roles(self, group_id, roles):
         """
         Assign realm roles to a group

--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -1016,6 +1016,13 @@ class KeycloakAdmin:
         return raise_error_from_response(data_raw, KeycloakGetError, expected_codes=[204])
 
     def get_realm_roles_of_user(self, user_id):
+        """
+        Get all realm roles for a user.
+
+        :param user_id: id of user
+        :return: Keycloak server response (array RoleRepresentation)
+        """
+
         params_path = {"realm-name": self.realm_name, "id": user_id}
         data_raw = self.raw_get(URL_ADMIN_USER_REALM_ROLES.format(**params_path))
         return raise_error_from_response(data_raw, KeycloakGetError)


### PR DESCRIPTION
This PR is for adding the operation "get_realm_roles_of_user". 
Currently there is an operation "assign_realm_roles" that is used to assigned realm roles to a specific user. 
However there is no way to retrieve this information using KeycloakAdmin.
This method allows to read this information.

GET /admin/realms/{realm-name}/users/{id}/role-mappings/realm