### PR TITLE
BugFix: Correct get/delete_group_client_roles methods. 

### DIFF
--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -1078,7 +1078,6 @@ class KeycloakAdmin:
 
         :param group_id: id of group
         :param client_id: id of client (not client-id)
-        :param roles: roles list or role (use GroupRoleRepresentation)
         :return Keycloak server response
         """
 

--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -1072,9 +1072,9 @@ class KeycloakAdmin:
                                  data=json.dumps(payload))
         return raise_error_from_response(data_raw, KeycloakGetError, expected_codes=[204])
 
-    def delete_group_client_roles(self, group_id, client_id, roles):
+    def get_group_client_roles(self, group_id, client_id):
         """
-        Delete client roles of a group
+        Get client roles of a group
 
         :param group_id: id of group
         :param client_id: id of client (not client-id)
@@ -1082,14 +1082,13 @@ class KeycloakAdmin:
         :return Keycloak server response
         """
 
-        payload = roles if isinstance(roles, list) else [roles]
         params_path = {"realm-name": self.realm_name, "id": group_id, "client-id": client_id}
         data_raw = self.raw_get(URL_ADMIN_GROUPS_CLIENT_ROLES.format(**params_path))
         return raise_error_from_response(data_raw, KeycloakGetError)
 
-    def get_group_client_roles(self, group_id, client_id, roles):
+    def delete_group_client_roles(self, group_id, client_id, roles):
         """
-        Get client roles of a group
+        Delete client roles of a group
 
         :param group_id: id of group
         :param client_id: id of client (not client-id)


### PR DESCRIPTION
The get_group_client_role & delete_group_client_role methods were mismatched with the underlying executing code. 
1) Changed the method names to reflect the underlying raw_delete & raw_get respectively. (delete allows payload, get does not)
2) Removed roles parameter from get_group_client_role and  from the description.