### PR TITLE
Fixes #137 and implements missing Admin REST API methods for working with authentication flows

### DIFF
--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -44,7 +44,7 @@ from .urls_patterns import URL_ADMIN_SERVER_INFO, URL_ADMIN_CLIENT_AUTHZ_RESOURC
     URL_ADMIN_CLIENT_SCOPES_ADD_MAPPER, URL_ADMIN_CLIENT_SCOPE, URL_ADMIN_CLIENT_SECRETS, \
     URL_ADMIN_USER_REALM_ROLES, URL_ADMIN_REALM, URL_ADMIN_COMPONENTS, URL_ADMIN_COMPONENT, URL_ADMIN_KEYS, \
     URL_ADMIN_USER_FEDERATED_IDENTITY, URL_ADMIN_USER_FEDERATED_IDENTITIES, \
-    URL_ADMIN_FLOWS_EXECUTIONS_EXEUCUTION, URL_ADMIN_FLOWS_EXECUTIONS_FLOW
+    URL_ADMIN_FLOWS_EXECUTIONS_EXEUCUTION, URL_ADMIN_FLOWS_EXECUTIONS_FLOW, URL_ADMIN_FLOWS_COPY
 
 
 class KeycloakAdmin:
@@ -1183,6 +1183,21 @@ class KeycloakAdmin:
         data_raw = self.raw_post(URL_ADMIN_FLOWS.format(**params_path),
                                  data=payload)
         return raise_error_from_response(data_raw, KeycloakGetError, expected_codes=[201], skip_exists=skip_exists)
+
+    def copy_authentication_flow(self, payload, flow_alias):
+        """
+        Copy existing authentication flow under a new name. The new name is given as 'newName' attribute of the passed payload.
+
+        :param payload: JSON containing 'newName' attribute
+        :param flow_alias: the flow alias
+        :return: Keycloak server response (RoleRepresentation)
+        """
+
+        params_path = {"realm-name": self.realm_name, "flow-alias": flow_alias}
+        data_raw = self.raw_post(URL_ADMIN_FLOWS_COPY.format(**params_path),
+                                 data=payload)
+        return raise_error_from_response(data_raw, KeycloakGetError, expected_codes=[201])
+
 
     def get_authentication_flow_executions(self, flow_alias):
         """

--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -43,7 +43,7 @@ from .urls_patterns import URL_ADMIN_SERVER_INFO, URL_ADMIN_CLIENT_AUTHZ_RESOURC
     URL_ADMIN_USER_CLIENT_ROLES_AVAILABLE, URL_ADMIN_USERS, URL_ADMIN_CLIENT_SCOPES, \
     URL_ADMIN_CLIENT_SCOPES_ADD_MAPPER, URL_ADMIN_CLIENT_SCOPE, URL_ADMIN_CLIENT_SECRETS, \
     URL_ADMIN_USER_REALM_ROLES, URL_ADMIN_REALM, URL_ADMIN_COMPONENTS, URL_ADMIN_COMPONENT, URL_ADMIN_KEYS, \
-    URL_ADMIN_USER_FEDERATED_IDENTITY, URL_ADMIN_USER_FEDERATED_IDENTITIES
+    URL_ADMIN_USER_FEDERATED_IDENTITY, URL_ADMIN_USER_FEDERATED_IDENTITIES, URL_ADMIN_FLOWS_SUBFLOWS
 
 
 class KeycloakAdmin:
@@ -1210,6 +1210,24 @@ class KeycloakAdmin:
         data_raw = self.raw_put(URL_ADMIN_FLOWS_EXECUTIONS.format(**params_path),
                                 data=payload)
         return raise_error_from_response(data_raw, KeycloakGetError, expected_codes=[204])
+
+    def create_authentication_flow_subflow(self, payload, flow_alias, skip_exists=False):
+        """
+        Create a new sub authentication flow for a given authentication flow
+
+        AuthenticationFlowRepresentation
+        https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_authenticationflowrepresentation
+
+        :param payload: AuthenticationFlowRepresentation
+        :param flow_alias: The flow alias
+        :param skip_exists: If true then do not raise an error if authentication flow already exists
+        :return: Keycloak server response (RoleRepresentation)
+        """
+
+        params_path = {"realm-name": self.realm_name, "flow-alias": flow_alias}
+        data_raw = self.raw_post(URL_ADMIN_FLOWS_SUBFLOWS.format(**params_path),
+                                 data=payload)
+        return raise_error_from_response(data_raw, KeycloakGetError, expected_codes=[201], skip_exists=skip_exists)
 
     def sync_users(self, storage_id, action):
         """

--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -44,7 +44,8 @@ from .urls_patterns import URL_ADMIN_SERVER_INFO, URL_ADMIN_CLIENT_AUTHZ_RESOURC
     URL_ADMIN_CLIENT_SCOPES_ADD_MAPPER, URL_ADMIN_CLIENT_SCOPE, URL_ADMIN_CLIENT_SECRETS, \
     URL_ADMIN_USER_REALM_ROLES, URL_ADMIN_REALM, URL_ADMIN_COMPONENTS, URL_ADMIN_COMPONENT, URL_ADMIN_KEYS, \
     URL_ADMIN_USER_FEDERATED_IDENTITY, URL_ADMIN_USER_FEDERATED_IDENTITIES, \
-    URL_ADMIN_FLOWS_EXECUTIONS_EXEUCUTION, URL_ADMIN_FLOWS_EXECUTIONS_FLOW, URL_ADMIN_FLOWS_COPY
+    URL_ADMIN_FLOWS_EXECUTIONS_EXEUCUTION, URL_ADMIN_FLOWS_EXECUTIONS_FLOW, URL_ADMIN_FLOWS_COPY, \
+    URL_ADMIN_FLOWS_ALIAS
 
 
 class KeycloakAdmin:
@@ -1166,6 +1167,20 @@ class KeycloakAdmin:
         params_path = {"realm-name": self.realm_name}
         data_raw = self.raw_get(URL_ADMIN_FLOWS.format(**params_path))
         return raise_error_from_response(data_raw, KeycloakGetError)
+    
+    def get_authentication_flow_for_id(self, flow_id):
+        """
+        Get one authentication flow by it's id/alias. Returns all flow details
+
+        AuthenticationFlowRepresentation
+        https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_authenticationflowrepresentation
+        
+        :param flow_id: the id of a flow NOT it's alias
+        :return: Keycloak server response (AuthenticationFlowRepresentation)
+        """
+        params_path = {"realm-name": self.realm_name, "flow-id": flow_id}
+        data_raw = self.raw_get(URL_ADMIN_FLOWS_ALIAS.format(**params_path))
+        return raise_error_from_response(data_raw, KeycloakGetError)
 
     def create_authentication_flow(self, payload, skip_exists=False):
         """
@@ -1197,7 +1212,6 @@ class KeycloakAdmin:
         data_raw = self.raw_post(URL_ADMIN_FLOWS_COPY.format(**params_path),
                                  data=payload)
         return raise_error_from_response(data_raw, KeycloakGetError, expected_codes=[201])
-
 
     def get_authentication_flow_executions(self, flow_alias):
         """

--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -43,7 +43,8 @@ from .urls_patterns import URL_ADMIN_SERVER_INFO, URL_ADMIN_CLIENT_AUTHZ_RESOURC
     URL_ADMIN_USER_CLIENT_ROLES_AVAILABLE, URL_ADMIN_USERS, URL_ADMIN_CLIENT_SCOPES, \
     URL_ADMIN_CLIENT_SCOPES_ADD_MAPPER, URL_ADMIN_CLIENT_SCOPE, URL_ADMIN_CLIENT_SECRETS, \
     URL_ADMIN_USER_REALM_ROLES, URL_ADMIN_REALM, URL_ADMIN_COMPONENTS, URL_ADMIN_COMPONENT, URL_ADMIN_KEYS, \
-    URL_ADMIN_USER_FEDERATED_IDENTITY, URL_ADMIN_USER_FEDERATED_IDENTITIES, URL_ADMIN_FLOWS_SUBFLOWS
+    URL_ADMIN_USER_FEDERATED_IDENTITY, URL_ADMIN_USER_FEDERATED_IDENTITIES, \
+    URL_ADMIN_FLOWS_EXECUTIONS_EXEUCUTION, URL_ADMIN_FLOWS_EXECUTIONS_FLOW
 
 
 class KeycloakAdmin:
@@ -1210,6 +1211,23 @@ class KeycloakAdmin:
         data_raw = self.raw_put(URL_ADMIN_FLOWS_EXECUTIONS.format(**params_path),
                                 data=payload)
         return raise_error_from_response(data_raw, KeycloakGetError, expected_codes=[204])
+    
+    def create_authentication_flow_execution(self, payload, flow_alias):
+        """
+        Create an authentication flow execution
+
+        AuthenticationExecutionInfoRepresentation
+        https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_authenticationexecutioninforepresentation
+
+        :param payload: AuthenticationExecutionInfoRepresentation
+        :param flow_alias: The flow alias
+        :return: Keycloak server response
+        """
+
+        params_path = {"realm-name": self.realm_name, "flow-alias": flow_alias}
+        data_raw = self.raw_post(URL_ADMIN_FLOWS_EXECUTIONS_EXEUCUTION.format(**params_path),
+                                data=payload)
+        return raise_error_from_response(data_raw, KeycloakGetError, expected_codes=[201])
 
     def create_authentication_flow_subflow(self, payload, flow_alias, skip_exists=False):
         """
@@ -1225,7 +1243,7 @@ class KeycloakAdmin:
         """
 
         params_path = {"realm-name": self.realm_name, "flow-alias": flow_alias}
-        data_raw = self.raw_post(URL_ADMIN_FLOWS_SUBFLOWS.format(**params_path),
+        data_raw = self.raw_post(URL_ADMIN_FLOWS_EXECUTIONS_FLOW.format(**params_path),
                                  data=payload)
         return raise_error_from_response(data_raw, KeycloakGetError, expected_codes=[201], skip_exists=skip_exists)
 

--- a/keycloak/urls_patterns.py
+++ b/keycloak/urls_patterns.py
@@ -80,9 +80,9 @@ URL_ADMIN_REALM = "admin/realms/{realm-name}"
 URL_ADMIN_IDPS = "admin/realms/{realm-name}/identity-provider/instances"
 URL_ADMIN_REALM_ROLES_ROLE_BY_NAME = "admin/realms/{realm-name}/roles/{role-name}"
 
-
 URL_ADMIN_FLOWS = "admin/realms/{realm-name}/authentication/flows"
 URL_ADMIN_FLOWS_EXECUTIONS = "admin/realms/{realm-name}/authentication/flows/{flow-alias}/executions"
+URL_ADMIN_FLOWS_SUBFLOWS = "admin/realms/{realm-name}/authentication/flows/{flow-alias}/executions/flow"
 
 URL_ADMIN_COMPONENTS = "admin/realms/{realm-name}/components"
 URL_ADMIN_COMPONENT = "admin/realms/{realm-name}/components/{component-id}"

--- a/keycloak/urls_patterns.py
+++ b/keycloak/urls_patterns.py
@@ -82,7 +82,8 @@ URL_ADMIN_REALM_ROLES_ROLE_BY_NAME = "admin/realms/{realm-name}/roles/{role-name
 
 URL_ADMIN_FLOWS = "admin/realms/{realm-name}/authentication/flows"
 URL_ADMIN_FLOWS_EXECUTIONS = "admin/realms/{realm-name}/authentication/flows/{flow-alias}/executions"
-URL_ADMIN_FLOWS_SUBFLOWS = "admin/realms/{realm-name}/authentication/flows/{flow-alias}/executions/flow"
+URL_ADMIN_FLOWS_EXECUTIONS_EXEUCUTION = "admin/realms/{realm-name}/authentication/flows/{flow-alias}/executions/execution"
+URL_ADMIN_FLOWS_EXECUTIONS_FLOW = "admin/realms/{realm-name}/authentication/flows/{flow-alias}/executions/flow"
 
 URL_ADMIN_COMPONENTS = "admin/realms/{realm-name}/components"
 URL_ADMIN_COMPONENT = "admin/realms/{realm-name}/components/{component-id}"

--- a/keycloak/urls_patterns.py
+++ b/keycloak/urls_patterns.py
@@ -81,6 +81,7 @@ URL_ADMIN_IDPS = "admin/realms/{realm-name}/identity-provider/instances"
 URL_ADMIN_REALM_ROLES_ROLE_BY_NAME = "admin/realms/{realm-name}/roles/{role-name}"
 
 URL_ADMIN_FLOWS = "admin/realms/{realm-name}/authentication/flows"
+URL_ADMIN_FLOWS_ALIAS = "admin/realms/{realm-name}/authentication/flows/{flow-id}"
 URL_ADMIN_FLOWS_COPY = "admin/realms/{realm-name}/authentication/flows/{flow-alias}/copy"
 URL_ADMIN_FLOWS_EXECUTIONS = "admin/realms/{realm-name}/authentication/flows/{flow-alias}/executions"
 URL_ADMIN_FLOWS_EXECUTIONS_EXEUCUTION = "admin/realms/{realm-name}/authentication/flows/{flow-alias}/executions/execution"

--- a/keycloak/urls_patterns.py
+++ b/keycloak/urls_patterns.py
@@ -81,6 +81,7 @@ URL_ADMIN_IDPS = "admin/realms/{realm-name}/identity-provider/instances"
 URL_ADMIN_REALM_ROLES_ROLE_BY_NAME = "admin/realms/{realm-name}/roles/{role-name}"
 
 URL_ADMIN_FLOWS = "admin/realms/{realm-name}/authentication/flows"
+URL_ADMIN_FLOWS_COPY = "admin/realms/{realm-name}/authentication/flows/{flow-alias}/copy"
 URL_ADMIN_FLOWS_EXECUTIONS = "admin/realms/{realm-name}/authentication/flows/{flow-alias}/executions"
 URL_ADMIN_FLOWS_EXECUTIONS_EXEUCUTION = "admin/realms/{realm-name}/authentication/flows/{flow-alias}/executions/execution"
 URL_ADMIN_FLOWS_EXECUTIONS_FLOW = "admin/realms/{realm-name}/authentication/flows/{flow-alias}/executions/flow"


### PR DESCRIPTION
Fixes #137 .
These Admin REST API methods have been implemented for working with authentication flows:
- get_authentication_flow_for_id
- copy_authentication_flow
- create_authentication_flow_execution
- create_authentication_flow_subflow