### PR TITLE
Inherit OpenID request headers and cookies to interact with Admin endpoints

### DIFF
--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -26,6 +26,7 @@
 
 import json
 from builtins import isinstance
+from copy import deepcopy
 from typing import Iterable
 
 from .connection import ConnectionManager
@@ -1737,10 +1738,8 @@ class KeycloakAdmin:
             # merge custom headers to main headers
             headers.update(self.custom_headers)
             
-        self._connection = ConnectionManager(base_url=self.server_url,
-                                             headers=headers,
-                                             timeout=60,
-                                             verify=self.verify)
+        self._connection = deepcopy(self.keycloak_openid.connection())
+        self._connection._headers.update(headers)
 
     def refresh_token(self):
         refresh_token = self.token.get('refresh_token')


### PR DESCRIPTION
It's detrimental to use two different requests sessions, because Keycloak may be behind reverse-proxy or some kind of balancer, so a client will end up talking to different servers for OpenID and Admin endpoints (two different sticky cookies for example).

Here is a very quick fix, so any suggestion is welcome.