### PR TITLE
Add exist_ok attribute to KeycloakAdmin.create_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The documentation for python-keycloak is available on [readthedocs](http://pytho
 * [Josha Inglis](https://bitbucket.org/joshainglis/)
 * [Alex](https://bitbucket.org/alex_zel/)
 * [Ewan Jone](https://bitbucket.org/kisamoto/)
+* [Lukas Martini](https://github.com/lutoma)
 
 ## Usage
 
@@ -125,6 +126,15 @@ new_user = keycloak_admin.create_user({"email": "example@example.com",
                     "enabled": True,
                     "firstName": "Example",
                     "lastName": "Example"})    
+
+# Add user and raise exception if username already exists
+# exist_ok currently defaults to True for backwards compatibility reasons
+new_user = keycloak_admin.create_user({"email": "example@example.com",
+                    "username": "example@example.com",
+                    "enabled": True,
+                    "firstName": "Example",
+                    "lastName": "Example"},
+                    exist_ok=False)
                                         
 # Add user and set password                    
 new_user = keycloak_admin.create_user({"email": "example@example.com",

--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -361,7 +361,7 @@ class KeycloakAdmin:
         data_raw = self.raw_delete(URL_ADMIN_IDP.format(**params_path))
         return raise_error_from_response(data_raw, KeycloakGetError, expected_codes=[204])
 
-    def create_user(self, payload):
+    def create_user(self, payload, exist_ok=True):
         """
         Create a new user. Username must be unique
 
@@ -369,15 +369,17 @@ class KeycloakAdmin:
         https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_userrepresentation
 
         :param payload: UserRepresentation
+        :param exist_ok: If False, raise KeycloakGetError if username already exists. Otherwise, return existing user ID.
 
         :return: UserRepresentation
         """
         params_path = {"realm-name": self.realm_name}
 
-        exists = self.get_user_id(username=payload['username'])
+        if exist_ok:
+            exists = self.get_user_id(username=payload['username'])
 
-        if exists is not None:
-            return str(exists)
+            if exists is not None:
+                return str(exists)
 
         data_raw = self.raw_post(URL_ADMIN_USERS.format(**params_path),
                                  data=json.dumps(payload))


### PR DESCRIPTION
This PR aims to address the issue raised in #66 in a backwards-compatible way. 

I've added a new parameter `exist_ok` that defaults to True. When set, it uses the current behaviour of running `get_user_id` and returning the current user ID if a user already exists.

When set to False, the check is skipped, and if a user already exists with the given username the API error is passed through as the standard `KeycloakGetError` exception.

I've chosen the parameter name `exist_ok` because that's what a number of Python standard library functions use for similar purposes (For example [Path.mkdir](https://docs.python.org/3/library/pathlib.html#pathlib.Path.mkdir)).