### PR TITLE
Added destructor to close requests.Session

### DIFF
--- a/keycloak/connection.py
+++ b/keycloak/connection.py
@@ -60,6 +60,9 @@ class ConnectionManager(object):
 
             self._s.mount(protocol, adapter)
 
+    def __del__(self):
+        self._s.close()
+
     @property
     def base_url(self):
         """ Return base url in use for requests to the server. """

--- a/keycloak/tests/test_connection.py
+++ b/keycloak/tests/test_connection.py
@@ -156,34 +156,36 @@ class TestConnection(unittest.TestCase):
         with mock.patch.object(KeycloakOpenID, "__init__", return_value=None) as mock_keycloak_open_id:
             with mock.patch("keycloak.keycloak_openid.KeycloakOpenID.token", return_value=fake_token):
                 with mock.patch("keycloak.connection.ConnectionManager.__init__", return_value=None) as mock_connection_manager:
-                    server_url = "https://localhost/auth/"
-                    username = "admin"
-                    password = "secret"
-                    realm_name = "master"
+                    with mock.patch("keycloak.connection.ConnectionManager.__del__", return_value=None) as mock_connection_manager_delete:
+                        server_url = "https://localhost/auth/"
+                        username = "admin"
+                        password = "secret"
+                        realm_name = "master"
 
-                    headers = {
-                        'Custom': 'test-custom-header'
-                    }
-                    KeycloakAdmin(server_url=server_url,
-                                  username=username,
-                                  password=password,
-                                  realm_name=realm_name,
-                                  verify=False,
-                                  custom_headers=headers)
+                        headers = {
+                            'Custom': 'test-custom-header'
+                        }
+                        KeycloakAdmin(server_url=server_url,
+                                      username=username,
+                                      password=password,
+                                      realm_name=realm_name,
+                                      verify=False,
+                                      custom_headers=headers)
 
-                    mock_keycloak_open_id.assert_called_with(server_url=server_url,
-                                                             realm_name=realm_name,
-                                                             client_id='admin-cli',
-                                                             client_secret_key=None,
-                                                             verify=False,
-                                                             custom_headers=headers)
+                        mock_keycloak_open_id.assert_called_with(server_url=server_url,
+                                                                 realm_name=realm_name,
+                                                                 client_id='admin-cli',
+                                                                 client_secret_key=None,
+                                                                 verify=False,
+                                                                 custom_headers=headers)
 
-                    expected_header = {'Authorization': 'Bearer faketoken',
-                                       'Content-Type': 'application/json',
-                                       'Custom': 'test-custom-header'
-                                       }
+                        expected_header = {'Authorization': 'Bearer faketoken',
+                                           'Content-Type': 'application/json',
+                                           'Custom': 'test-custom-header'
+                                           }
 
-                    mock_connection_manager.assert_called_with(base_url=server_url,
-                                                               headers=expected_header,
-                                                               timeout=60,
-                                                               verify=False)
+                        mock_connection_manager.assert_called_with(base_url=server_url,
+                                                                   headers=expected_header,
+                                                                   timeout=60,
+                                                                   verify=False)
+                        mock_connection_manager_delete.assert_called_once_with()


### PR DESCRIPTION
To resolve ResourceWarnings from requests lib about unclosed SSLSockets - see psf/requests#1882. 
It happens on pytest==6.2
`pytest.PytestUnraisableExceptionWarning: Exception ignored in: <ssl.SSLSocket fd=-1, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>`

`               Traceback (most recent call last):
                 File "/src/common/tests/integration/auth_keycloak_service_tests.py", line 6, in test_decode_auth_token
                   token = get_auth_token()
               ResourceWarning: unclosed <ssl.SSLSocket fd=7, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('172.28.0.10', 44592),>`