### PR TITLE
BugFix get_user_id to non case-sensitive

### DIFF
--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -410,9 +410,9 @@ class KeycloakAdmin:
 
         :return: user_id
         """
-
-        users = self.get_users(query={"search": username})
-        return next((user["id"] for user in users if user["username"] == username), None)
+        lower_user_name = username.lower()
+        users = self.get_users(query={"search": lower_user_name})
+        return next((user["id"] for user in users if user["username"] == lower_user_name), None)
 
     def get_user(self, user_id):
         """


### PR DESCRIPTION
You can do this by first registering a user with uppercase letters by create_user(), 
but the second time get_user_id() makes it None, so 409 is returned.

The cause is that KeyCloak converts the user name to lowercase and registers it.
(https://issues.redhat.com/browse/KEYCLOAK-2858)
Therefore, I modified to convert the user_name that came in with get_user_id to lowercase and compare it.

Hope to see the feature merged soon and ready for use! :)