### PR TITLE
Added realm partial export feature

### DIFF
--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -247,6 +247,12 @@ class KeycloakAdmin:
         """
         Export the realm configurations in the json format
 
+        RealmRepresentation
+        https://www.keycloak.org/docs-api/5.0/rest-api/index.html#_partialexport
+
+        :param export-clients: Skip if not want to export realm clients
+        :param export-groups-and-roles: Skip if not want to export realm groups and roles
+        
         :return: realm configurations JSON
         """
         params_path = {"realm-name": self.realm_name, "export-clients": export_clients, "export-groups-and-roles": export_groups_and_role }

--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -47,7 +47,8 @@ from .urls_patterns import URL_ADMIN_SERVER_INFO, URL_ADMIN_CLIENT_AUTHZ_RESOURC
     URL_ADMIN_REALM_ROLES_MEMBERS, URL_ADMIN_CLIENT_PROTOCOL_MAPPER, URL_ADMIN_CLIENT_SCOPES_MAPPERS, \
     URL_ADMIN_FLOWS_EXECUTIONS_EXEUCUTION, URL_ADMIN_FLOWS_EXECUTIONS_FLOW, URL_ADMIN_FLOWS_COPY, \
     URL_ADMIN_FLOWS_ALIAS, URL_ADMIN_CLIENT_SERVICE_ACCOUNT_USER, URL_ADMIN_AUTHENTICATOR_CONFIG, \
-    URL_ADMIN_CLIENT_ROLES_COMPOSITE_CLIENT_ROLE, URL_ADMIN_CLIENT_ALL_SESSIONS, URL_ADMIN_EVENTS
+    URL_ADMIN_CLIENT_ROLES_COMPOSITE_CLIENT_ROLE, URL_ADMIN_CLIENT_ALL_SESSIONS, URL_ADMIN_EVENTS, \
+    URL_ADMIN_REALM_EXPORT
 
 
 class KeycloakAdmin:
@@ -241,6 +242,16 @@ class KeycloakAdmin:
         data_raw = self.raw_post(URL_ADMIN_REALMS,
                                  data=json.dumps(payload))
         return raise_error_from_response(data_raw, KeycloakGetError, expected_codes=[201])
+
+    def export_realm(self, export_clients=False, export_groups_and_role=False):
+        """
+        Export the realm configurations in the json format
+
+        :return: realm configurations JSON
+        """
+        params_path = {"realm-name": self.realm_name, "export-clients": export_clients, "export-groups-and-roles": export_groups_and_role }
+        data_raw = self.raw_post(URL_ADMIN_REALM_EXPORT.format(**params_path), data="")
+        return raise_error_from_response(data_raw, KeycloakGetError)
 
     def get_realms(self):
         """

--- a/keycloak/urls_patterns.py
+++ b/keycloak/urls_patterns.py
@@ -89,6 +89,7 @@ URL_ADMIN_IDP_MAPPERS = "admin/realms/{realm-name}/identity-provider/instances/{
 URL_ADMIN_IDP = "admin/realms//{realm-name}/identity-provider/instances/{alias}"
 URL_ADMIN_REALM_ROLES_ROLE_BY_NAME = "admin/realms/{realm-name}/roles/{role-name}"
 URL_ADMIN_REALM_ROLES_COMPOSITE_REALM_ROLE = "admin/realms/{realm-name}/roles/{role-name}/composites"
+URL_ADMIN_REALM_EXPORT = "admin/realms/{realm-name}/partial-export?exportClients={export-clients}&exportGroupsAndRoles={export-groups-and-roles}"
 
 URL_ADMIN_FLOWS = "admin/realms/{realm-name}/authentication/flows"
 URL_ADMIN_FLOWS_ALIAS = "admin/realms/{realm-name}/authentication/flows/{flow-id}"


### PR DESCRIPTION
# Feature Added: Realm partial export
### Description: This feature allow keycloak realm admins to export their realm partial configurations. The feature function will return JSON formatted string.

[Keycloak Partial Export URL Representation Official Rest API Doc](https://www.keycloak.org/docs-api/5.0/rest-api/index.html#_partialexport)

It takes to params as arguments, `export_clients` and `export_groups_and_role`, which by default are `False`.

```
# Keycloak Administrator
keycloak_admin = KeycloakAdmin(server_url="http://localhost:8080/auth/",
                               username='admin',
                               password='password',
                               realm_name="master",
                               verify=False)

# Export the realm partial configurations
keycloak_admin.export_realm(export_clients=False, export_groups_and_role=False)
```