### PR TITLE
Reduce amount of paginated requests. 

### DIFF
--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -223,6 +223,8 @@ class KeycloakAdmin:
             if not partial_results:
                 break
             results.extend(partial_results)
+            if len(partial_results) < query['max']:
+                break
             page += 1
         return results
 


### PR DESCRIPTION
For paginated requests we can reduce the amount of requests by one.
This is possible, by checking if the response does not exceed the current page maximum.


