### PR TITLE
Fix KeycloakAdmin using wrong realm when authenticating with a service account

### DIFF
--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -1827,14 +1827,17 @@ class KeycloakAdmin:
         return r
 
     def get_token(self):
+        token_realm_name = 'master' if self.client_secret_key else self.user_realm_name or self.realm_name
         self.keycloak_openid = KeycloakOpenID(server_url=self.server_url, client_id=self.client_id,
-                                              realm_name=self.user_realm_name or self.realm_name, verify=self.verify,
+                                              realm_name=token_realm_name, verify=self.verify,
                                               client_secret_key=self.client_secret_key,
                                               custom_headers=self.custom_headers)
 
         grant_type = ["password"]
         if self.client_secret_key:
             grant_type = ["client_credentials"]
+            if self.user_realm_name:
+                self.realm_name = self.user_realm_name
 
         self._token = self.keycloak_openid.token(self.username, self.password, grant_type=grant_type)
 


### PR DESCRIPTION
Hi, I wanted to use a service account to do admin tasks on a different realm so instead of username and password, I supply client_id and client_secret of a service account on a master realm to KeycloakAdmin as described [here](https://www.keycloak.org/docs/latest/server_development/#authenticate-with-a-service-account). But then it was fetching service account token from the user realm where I store actual users which is not the master realm and doesn't have the service account.

So what I did was to select master realm for token acquisition based on whether or not I supply client secret of the service account. Then I select the user realm on which we do the API calls based on whether or not it was supplied during KeycloakAdmin instantiation.