### PR TITLE
Add feature to list and delete user credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,15 @@ response = keycloak_admin.update_user(user_id="user-id-keycloak",
 
 # Update User Password
 response = keycloak_admin.set_user_password(user_id="user-id-keycloak", password="secret", temporary=True)
+
+# Get User Credentials
+credentials = keycloak_admin.get_credentials(user_id='user_id')
+
+# Get User Credential by ID
+credential = keycloak_admin.get_credential(user_id='user_id', credential_id='credential_id')
+
+# Delete User Credential
+response = keycloak_admin.delete_credential(user_id='user_id', credential_id='credential_id')
                                       
 # Delete User
 response = keycloak_admin.delete_user(user_id="user-id-keycloak")

--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -48,7 +48,8 @@ from .urls_patterns import URL_ADMIN_SERVER_INFO, URL_ADMIN_CLIENT_AUTHZ_RESOURC
     URL_ADMIN_FLOWS_EXECUTIONS_EXEUCUTION, URL_ADMIN_FLOWS_EXECUTIONS_FLOW, URL_ADMIN_FLOWS_COPY, \
     URL_ADMIN_FLOWS_ALIAS, URL_ADMIN_CLIENT_SERVICE_ACCOUNT_USER, URL_ADMIN_AUTHENTICATOR_CONFIG, \
     URL_ADMIN_CLIENT_ROLES_COMPOSITE_CLIENT_ROLE, URL_ADMIN_CLIENT_ALL_SESSIONS, URL_ADMIN_EVENTS, \
-    URL_ADMIN_REALM_EXPORT, URL_ADMIN_DELETE_USER_ROLE, URL_ADMIN_USER_LOGOUT
+    URL_ADMIN_REALM_EXPORT, URL_ADMIN_DELETE_USER_ROLE, URL_ADMIN_USER_LOGOUT, \
+    URL_ADMIN_USER_CREDENTIALS, URL_ADMIN_USER_CREDENTIAL
 
 
 class KeycloakAdmin:
@@ -505,6 +506,50 @@ class KeycloakAdmin:
         data_raw = self.raw_put(URL_ADMIN_RESET_PASSWORD.format(**params_path),
                                 data=json.dumps(payload))
         return raise_error_from_response(data_raw, KeycloakGetError, expected_codes=[204])
+
+    def get_credentials(self, user_id):
+        """
+        Returns a list of credential belonging to the user.
+
+        CredentialRepresentation
+        https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_credentialrepresentation
+
+        :param: user_id: user id
+        :return: Keycloak server response (CredentialRepresentation)
+        """
+        params_path = {"realm-name": self.realm_name, "id": user_id}
+        data_raw = self.raw_get(URL_ADMIN_USER_CREDENTIALS.format(**params_path))
+        return raise_error_from_response(data_raw, KeycloakGetError)
+
+    def get_credential(self, user_id, credential_id):
+        """
+        Get credential of the user.
+
+        CredentialRepresentation
+        https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_credentialrepresentation
+
+        :param: user_id: user id
+        :param: credential_id: credential id
+        :return: Keycloak server response (ClientRepresentation)
+        """
+        params_path = {"realm-name": self.realm_name, "id": user_id, "credential_id": credential_id}
+        data_raw = self.raw_get(URL_ADMIN_USER_CREDENTIAL.format(**params_path))
+        return raise_error_from_response(data_raw, KeycloakGetError)
+
+    def delete_credential(self, user_id, credential_id):
+        """
+        Delete credential of the user.
+
+        CredentialRepresentation
+        https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_credentialrepresentation
+
+        :param: user_id: user id
+        :param: credential_id: credential id
+        :return: Keycloak server response (ClientRepresentation)
+        """
+        params_path = {"realm-name": self.realm_name, "id": user_id, "credential_id": credential_id}
+        data_raw = self.raw_delete(URL_ADMIN_USER_CREDENTIAL.format(**params_path))
+        return raise_error_from_response(data_raw, KeycloakGetError)
 
     def logout(self, user_id):
         """

--- a/keycloak/urls_patterns.py
+++ b/keycloak/urls_patterns.py
@@ -50,6 +50,8 @@ URL_ADMIN_USER_CLIENT_ROLES_COMPOSITE = "admin/realms/{realm-name}/users/{id}/ro
 URL_ADMIN_USER_GROUP = "admin/realms/{realm-name}/users/{id}/groups/{group-id}"
 URL_ADMIN_USER_GROUPS = "admin/realms/{realm-name}/users/{id}/groups"
 URL_ADMIN_USER_PASSWORD = "admin/realms/{realm-name}/users/{id}/reset-password"
+URL_ADMIN_USER_CREDENTIALS = "admin/realms/{realm-name}/users/{id}/credentials"
+URL_ADMIN_USER_CREDENTIAL = "admin/realms/{realm-name}/users/{id}/credentials/{credential_id}"
 URL_ADMIN_USER_LOGOUT = "admin/realms/{realm-name}/users/{id}/logout"
 URL_ADMIN_USER_STORAGE = "admin/realms/{realm-name}/user-storage/{id}/sync"
 


### PR DESCRIPTION
User [credential](https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_credentialrepresentation) is used to store secret information like current password, password history, otp token etc.

I added 3 functions to retrieve and delete those credentials when needed. This feature comes handy when you want to **reuse password** for an user and cannot do it due to password policy (auto expire, prevent reuse) being enforced.

Here is my workaround.

```python
user_id = "a74e3f5a-7969-47f5-9667-69ead58fbb37"
user_password = "12345678"

# remove password history
for credential in keycloak_admin.get_credentials(user_id=user_id):
    if credential['type'] in ['password-history', 'password']:
        keycloak_admin.delete_credential(user_id=user_id, credential_id=credential['id'])

# set old password as new password
response = keycloak_admin.set_user_password(user_id=user_id, password=user_password, temporary=False)
```