### PR TITLE
Revert "Fix KeycloakAdmin using wrong realm when authenticating with …

### DIFF
--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -1873,17 +1873,14 @@ class KeycloakAdmin:
         return r
 
     def get_token(self):
-        token_realm_name = 'master' if self.client_secret_key else self.user_realm_name or self.realm_name
         self.keycloak_openid = KeycloakOpenID(server_url=self.server_url, client_id=self.client_id,
-                                              realm_name=token_realm_name, verify=self.verify,
+                                              realm_name=self.user_realm_name or self.realm_name, verify=self.verify,
                                               client_secret_key=self.client_secret_key,
                                               custom_headers=self.custom_headers)
 
         grant_type = ["password"]
         if self.client_secret_key:
             grant_type = ["client_credentials"]
-            if self.user_realm_name:
-                self.realm_name = self.user_realm_name
 
         self._token = self.keycloak_openid.token(self.username, self.password, grant_type=grant_type)
 


### PR DESCRIPTION
…a service account"

This reverts commit a9b39248543b521fe2a5936fe09b3d8509d681c0.

It seems like it is unnecessary to use master realm to authenticate as admin using service account so this reverts that faulty commit.