### PR TITLE
Handle refresh_token error "Session not active"

### DIFF
--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -1906,8 +1906,12 @@ class KeycloakAdmin:
         try:
             self.token = self.keycloak_openid.refresh_token(refresh_token)
         except KeycloakGetError as e:
-            if e.response_code == 400 and (b'Refresh token expired' in e.response_body or
-                                           b'Token is not active' in e.response_body):
+            list_errors = [
+                b'Refresh token expired',
+                b'Token is not active',
+                b'Session not active'
+            ]
+            if e.response_code == 400 and any(err in e.response_body for err in list_errors):
                 self.get_token()
             else:
                 raise


### PR DESCRIPTION
These changes are a re-submit of https://github.com/marcospereirampj/python-keycloak/pull/95.

I assume you closed this pull request in favor of https://github.com/marcospereirampj/python-keycloak/pull/99 which didn't fix the issue we were encountering something https://github.com/marcospereirampj/python-keycloak/pull/95 was doing. Our administrative scripts would fail some times with `Session not active` error. This change request fixes that issue.