### PR TITLE
Don't force realm name when using secret key

### DIFF
--- a/keycloak/keycloak_admin.py
+++ b/keycloak/keycloak_admin.py
@@ -1873,7 +1873,7 @@ class KeycloakAdmin:
         return r
 
     def get_token(self):
-        token_realm_name = 'master' if self.client_secret_key else self.user_realm_name or self.realm_name
+        token_realm_name = self.user_realm_name or self.realm_name
         self.keycloak_openid = KeycloakOpenID(server_url=self.server_url, client_id=self.client_id,
                                               realm_name=token_realm_name, verify=self.verify,
                                               client_secret_key=self.client_secret_key,


### PR DESCRIPTION
Using other realms can be useful, for example, to manage realm users with restricted rights.

It also was very unexpected -- I spent some time figuring out why can't I get my access token ;)