### PR TITLE
Added optional proxies for requests calls

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -100,6 +100,15 @@ Main methods::
     #                    verify=True,
     #                    custom_headers={'CustomHeader': 'value'})
 
+    # Optionally, you can pass proxies as well that will be used in all HTTP calls. See requests documentation for more details_
+    # `requests-proxies <https://2.python-requests.org/en/master/user/advanced/#id10>`_.
+    # keycloak_openid = KeycloakOpenID(server_url="http://localhost:8080/auth/",
+    #                    client_id="example_client",
+    #                    realm_name="example_realm",
+    #                    client_secret_key="secret",
+    #                    verify=True,
+    #                    proxies={'http': 'http://10.10.1.10:3128', 'https': 'http://10.10.1.10:1080'})
+
     # Get WellKnow
     config_well_know = keycloak_openid.well_know()
 

--- a/keycloak/connection.py
+++ b/keycloak/connection.py
@@ -39,9 +39,10 @@ class ConnectionManager(object):
         headers (dict): The header parameters of the requests to the server.
         timeout (int): Timeout to use for requests to the server.
         verify (bool): Verify server SSL.
+        proxies (dict): The proxies servers requests is sent by.
     """
 
-    def __init__(self, base_url, headers={}, timeout=60, verify=True):
+    def __init__(self, base_url, headers={}, timeout=60, verify=True, proxies=None):
         self._base_url = base_url
         self._headers = headers
         self._timeout = timeout
@@ -59,6 +60,9 @@ class ConnectionManager(object):
             adapter.max_retries.allowed_methods = frozenset(allowed_methods)
 
             self._s.mount(protocol, adapter)
+        
+        if proxies:
+            self._s.proxies = proxies
 
     def __del__(self):
         self._s.close()

--- a/keycloak/connection.py
+++ b/keycloak/connection.py
@@ -62,7 +62,7 @@ class ConnectionManager(object):
             self._s.mount(protocol, adapter)
         
         if proxies:
-            self._s.proxies = proxies
+            self._s.proxies.update(proxies)
 
     def __del__(self):
         self._s.close()

--- a/keycloak/keycloak_openid.py
+++ b/keycloak/keycloak_openid.py
@@ -44,7 +44,7 @@ from .urls_patterns import (
 
 class KeycloakOpenID:
 
-    def __init__(self, server_url, realm_name, client_id, client_secret_key=None, verify=True, custom_headers=None):
+    def __init__(self, server_url, realm_name, client_id, client_secret_key=None, verify=True, custom_headers=None, proxies=None):
         """
 
         :param server_url: Keycloak server url
@@ -53,6 +53,7 @@ class KeycloakOpenID:
         :param client_secret_key: client secret key
         :param verify: True if want check connection SSL
         :param custom_headers: dict of custom header to pass to each HTML request
+        :param proxies: dict of proxies to sent the request by.
         """
         self._client_id = client_id
         self._client_secret_key = client_secret_key
@@ -64,7 +65,8 @@ class KeycloakOpenID:
         self._connection = ConnectionManager(base_url=server_url,
                                              headers=headers,
                                              timeout=60,
-                                             verify=verify)
+                                             verify=verify,
+                                             proxies=proxies)
 
         self._authorization = Authorization()
 


### PR DESCRIPTION
This PR aims to provide a way to add proxies to HTTP calls using requests proxies feature. It's useful in cases where Keycloak is IP restricted and using an proxy will grant access to it.