### PR TITLE
always publish wheels

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -9,5 +9,5 @@ username=${PYPI_USERNAME}
 password=${PYPI_PASSWORD}
 EOF
 
-python setup.py sdist bdist_wheel --universal
+python setup.py sdist bdist_wheel
 twine upload dist/*

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -9,5 +9,5 @@ username=${PYPI_USERNAME}
 password=${PYPI_PASSWORD}
 EOF
 
-python setup.py sdist
+python setup.py sdist bdist_wheel --universal
 twine upload dist/*


### PR DESCRIPTION
I don't know how you really push to pypi, but if you are using the bash script, all you need to do is add `bdist_wheel` and your library users get the more secure, newer library. You may or may not need to install the `wheel` library, I didn't check if it gets pulled in by one of your other build dependencies.

Ref: [How to do this with setup.py](https://www.realpythonproject.com/how-to-create-a-wheel-file-for-your-python-package-and-import-it-in-another-project/) 
