### PR TITLE
Fix wrong payload format in README.md samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ consents = keycloak_admin.consents_user(user_id="user-id-keycloak")
 
 # Send User Action
 response = keycloak_admin.send_update_account(user_id="user-id-keycloak", 
-                                              payload=json.dumps(['UPDATE_PASSWORD']))
+                                              payload=['UPDATE_PASSWORD'])
 
 # Send Verify Email
 response = keycloak_admin.send_verify_email(user_id="user-id-keycloak")


### PR DESCRIPTION
#155 introduced a change in the API in 0.25.0 and payload must now be passed as dict.

Maybe this should've been mentionned in the 0.25.0 changelog as well.