### PR TITLE
UMA-permission requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ keycloak_openid.load_authorization_config("example-authz-config.json")
 policies = keycloak_openid.get_policies(token['access_token'], method_token_info='decode', key=KEYCLOAK_PUBLIC_KEY)
 permissions = keycloak_openid.get_permissions(token['access_token'], method_token_info='introspect')
 
+# Get UMA-permissions by token
+token = keycloak_openid.token("user", "password")
+permissions = keycloak_openid.UMA_permissions(token['access_token'])
+
+# Get auth status for a specific resource and scope by token
+token = keycloak_openid.token("user", "password")
+auth_status = keycloak_openid.has_UMA_access(token['access_token'], "Resource#Scope")
+
+
 # KEYCLOAK ADMIN
 
 from keycloak import KeycloakAdmin

--- a/keycloak/exceptions.py
+++ b/keycloak/exceptions.py
@@ -81,6 +81,10 @@ class KeycloakPermissionFormatError(KeycloakOperationError):
     pass
 
 
+class PermissionDefinitionError(Exception):
+    pass
+
+
 def raise_error_from_response(response, error, expected_codes=None, skip_exists=False):
     if expected_codes is None:
         expected_codes = [200, 201, 204]

--- a/keycloak/exceptions.py
+++ b/keycloak/exceptions.py
@@ -56,6 +56,7 @@ class KeycloakOperationError(KeycloakError):
 class KeycloakDeprecationError(KeycloakError):
     pass
 
+
 class KeycloakGetError(KeycloakOperationError):
     pass
 
@@ -73,6 +74,10 @@ class KeycloakAuthorizationConfigError(KeycloakOperationError):
 
 
 class KeycloakInvalidTokenError(KeycloakOperationError):
+    pass
+
+
+class KeycloakPermissionFormatError(KeycloakOperationError):
     pass
 
 

--- a/keycloak/keycloak_openid.py
+++ b/keycloak/keycloak_openid.py
@@ -25,6 +25,7 @@ import json
 
 from jose import jwt
 
+from .uma_permissions import UMA_Permission
 from .authorization import Authorization
 from .connection import ConnectionManager
 from .exceptions import KeycloakPermissionFormatError, raise_error_from_response, KeycloakGetError, \
@@ -297,7 +298,6 @@ class KeycloakOpenID:
         data_raw = self.connection.raw_get(URL_REALM.format(**params_path))
         return raise_error_from_response(data_raw, KeycloakGetError)['public_key']
 
-
     def entitlement(self, token, resource_server_id):
         """
         Client applications can use a specific endpoint to obtain a special security token
@@ -523,7 +523,7 @@ def build_permission_param(permissions):
     """
     if permissions is None or permissions == "":
         return set()
-    if isinstance(permissions, str):
+    if isinstance(permissions, (str, UMA_Permission)):
         return set((permissions,))
 
     try:  # treat as dictionary of permissions
@@ -531,11 +531,11 @@ def build_permission_param(permissions):
         for resource, scopes in permissions.items():
             if scopes is None:
                 result.add(resource)
-            elif isinstance(scopes, str):
+            elif isinstance(scopes, (str, UMA_Permission)):
                 result.add("{}#{}".format(resource, scopes))
             else:
                 for scope in scopes:
-                    if not isinstance(scope, str):
+                    if not isinstance(scope, (str, UMA_Permission)):
                         raise KeycloakPermissionFormatError(
                             'misbuilt permission {}'.format(permissions))
                     result.add("{}#{}".format(resource, scope))

--- a/keycloak/keycloak_openid.py
+++ b/keycloak/keycloak_openid.py
@@ -173,7 +173,8 @@ class KeycloakOpenID:
         """
 
         params_path = {"realm-name": self.realm_name}
-        data_raw = self.connection.raw_get(URL_WELL_KNOWN.format(**params_path))
+        data_raw = self.connection.raw_get(
+            URL_WELL_KNOWN.format(**params_path))
 
         return raise_error_from_response(data_raw, KeycloakGetError)
 
@@ -235,7 +236,8 @@ class KeycloakOpenID:
         :return:
         """
         params_path = {"realm-name": self.realm_name}
-        payload = {"client_id": self.client_id, "grant_type": grant_type, "refresh_token": refresh_token}
+        payload = {"client_id": self.client_id,
+                   "grant_type": grant_type, "refresh_token": refresh_token}
         payload = self._add_secret_key(payload)
         data_raw = self.connection.raw_post(URL_TOKEN.format(**params_path),
                                             data=payload)
@@ -287,7 +289,7 @@ class KeycloakOpenID:
         params_path = {"realm-name": self.realm_name}
         data_raw = self.connection.raw_get(URL_CERTS.format(**params_path))
         return raise_error_from_response(data_raw, KeycloakGetError)
-    
+
     def public_key(self):
         """
         The public key is exposed by the realm page directly.
@@ -309,10 +311,12 @@ class KeycloakOpenID:
         :return:
         """
         self.connection.add_param_headers("Authorization", "Bearer " + token)
-        params_path = {"realm-name": self.realm_name, "resource-server-id": resource_server_id}
-        data_raw = self.connection.raw_get(URL_ENTITLEMENT.format(**params_path))
-        
-        if data_raw.status_code == 404: 
+        params_path = {"realm-name": self.realm_name,
+                       "resource-server-id": resource_server_id}
+        data_raw = self.connection.raw_get(
+            URL_ENTITLEMENT.format(**params_path))
+
+        if data_raw.status_code == 404:
             return raise_error_from_response(data_raw, KeycloakDeprecationError)
 
         return raise_error_from_response(data_raw, KeycloakGetError)
@@ -336,8 +340,10 @@ class KeycloakOpenID:
 
         if token_type_hint == 'requesting_party_token':
             if rpt:
-                payload.update({"token": rpt, "token_type_hint": token_type_hint})
-                self.connection.add_param_headers("Authorization", "Bearer " + token)
+                payload.update(
+                    {"token": rpt, "token_type_hint": token_type_hint})
+                self.connection.add_param_headers(
+                    "Authorization", "Bearer " + token)
             else:
                 raise KeycloakRPTNotFound("Can't found RPT.")
 

--- a/keycloak/tests/test_openid.py
+++ b/keycloak/tests/test_openid.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017 Marcos Pereira <marcospereira.mpj@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from ..keycloak_openid import *
+from ..exceptions import *
+try:
+    import unittest
+except ImportError:
+    import unittest2 as unittest
+
+from collections import namedtuple
+
+
+class Success(Exception):
+    """Used as stand-in for an actual exception for tests that are meant to succeed.
+    This exception should never be raised."""
+
+
+class TestOpenID(unittest.TestCase):
+    def test_build_permission_param(self):
+        test = namedtuple("test",
+                          ["name", "permission", "result", "error"])
+        tests = [
+            test("None", None, set(), Success),
+            test("empty str", "", set(), Success),
+            test("empty list", [], set(), Success),
+            test("empty tuple", (), set(), Success),
+            test("empty set", set(), set(), Success),
+            test("empty dict", {}, set(), Success),
+
+            test("str", "resource1", {"resource1"}, Success),
+
+            test("list[str]", ["res1#scope1", "res1#scope2"],
+                 {"res1#scope1", "res1#scope2"}, Success),
+
+            test("tuple[str]", ("res1#scope1", "res1#scope2"),
+                 {"res1#scope1", "res1#scope2"}, Success),
+
+            test("set[str]", {"res1#scope1", "res1#scope2"},
+                 {"res1#scope1", "res1#scope2"}, Success),
+
+            test("dict[str,str]", {"res1": "scope1"},
+                 {"res1#scope1"}, Success),
+            test("dict[str,list[str]]", {"res1": ["scope1", "scope2"]},
+                 {"res1#scope1", "res1#scope2"}, Success),
+            test("dict[str,list[str]] 2", {"res1": ["scope1", "scope2"], "res2": ["scope2", "scope3"]},
+                 {"res1#scope1", "res1#scope2", "res2#scope2", "res2#scope3"}, Success),
+
+            test("misbuilt: dict[str,list[list[str]]]", {
+                "res1": [["scope1", "scope2"]]}, None, KeycloakPermissionFormatError),
+            test("misbuilt: list[list[str]]",
+                 [["scope1", "scope2"]], None, KeycloakPermissionFormatError),
+            test("misbuilt: list[set[str]]",
+                 [{"scope1", "scope2"}], None, KeycloakPermissionFormatError),
+            test("misbuilt: set[set[str]]",
+                 [{"scope1"}], None, KeycloakPermissionFormatError),
+        ]
+
+        for case in tests:
+            with self.subTest(case.name):
+                msg = f'in case "{case.name}"'
+                try:
+                    if not case.error is Success:
+                        with self.assertRaises(case.error, msg=msg):
+                            build_permission_param(case.permission)
+                    else:
+                        self.assertEqual(
+                            build_permission_param(case.permission),
+                            case.result, msg=msg)
+                except AssertionError:
+                    raise
+                except Exception as e:
+                    self.fail(
+                        f'unexpected exception "{e}": {msg}')

--- a/keycloak/tests/test_uma_permissions.py
+++ b/keycloak/tests/test_uma_permissions.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017 Marcos Pereira <marcospereira.mpj@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from ..uma_permissions import *
+from ..exceptions import *
+try:
+    import unittest
+except ImportError:
+    import unittest2 as unittest
+
+from collections import namedtuple
+
+
+class Success(Exception):
+    """Used as stand-in for an actual exception for tests that are meant to succeed.
+    This exception should never be raised."""
+
+
+class TestOpenID(unittest.TestCase):
+    def test_call_permission(self):
+        test = namedtuple("test",
+                          ["name", "permission", "args", "kwargs", "result", "error"])
+        tests = [
+            test("Resource(Scope)", Resource("Resource1"),
+                 [Scope("Scope1")], {},
+                 "Resource1#Scope1", Success),
+            test("Scope(Resource)", Scope("Scope1"),
+                 [Resource("Resource1")], {},
+                 "Resource1#Scope1", Success),
+
+            test("Resource(scope=str)", Resource("Resource1"),
+                 [], {"scope": "Scope1"},
+                 "Resource1#Scope1", Success),
+            test("Scope(resource=str)", Scope("Scope1"),
+                 [], {"resource": "Resource1"},
+                 "Resource1#Scope1", Success),
+
+            test("Resource(str)", Resource("Resource1"),
+                 ["Scope1"], {},
+                 "", PermissionDefinitionError),
+        ]
+
+        for case in tests:
+            with self.subTest(case.name):
+                msg = f'in case "{case.name}"'
+                try:
+                    if not case.error is Success:
+                        with self.assertRaises(case.error, msg=msg):
+                            case.permission(*case.args, **case.kwargs)
+                    else:
+                        self.assertEqual(
+                            case.permission(*case.args, **case.kwargs),
+                            case.result, msg=msg)
+                except AssertionError:
+                    raise
+                except Exception as e:
+                    self.fail(
+                        f'unexpected exception "{e}": {msg}')

--- a/keycloak/uma_permissions.py
+++ b/keycloak/uma_permissions.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+#
+# The MIT License (MIT)
+#
+# Copyright (C) 2017 Marcos Pereira <marcospereira.mpj@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+from keycloak.exceptions import PermissionDefinitionError
+
+
+class UMA_Permission():
+    """A class to conveniently assembly permissions.
+    The class itself is callable, and will return the assembled permission.
+
+    Usage example:
+
+    >>> r = Resource("Users")
+    >>> s = Scope("delete")
+    >>> permission = r(s)
+    >>> print(permission)
+        'Users#delete'
+
+    """
+
+    def __init__(self, *, resource="", scope=""):
+        self.resource = resource
+        self.scope = scope
+
+    def __str__(self):
+        scope = self.scope
+        if scope:
+            scope = "#"+scope
+        return "{}{}".format(self.resource, scope)
+
+    def __eq__(self, __o: object) -> bool:
+        return str(self) == str(__o)
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+    def __hash__(self) -> int:
+        return hash(str(self))
+
+    def __call__(self, *args, resource="", scope="") -> object:
+        result_resource = self.resource
+        result_scope = self.scope
+
+        for arg in args:
+            if not isinstance(arg, UMA_Permission):
+                raise PermissionDefinitionError(
+                    "can't determine if '{}' is a resource or scope".format(arg))
+            if arg.resource:
+                result_resource = str(arg.resource)
+            if arg.scope:
+                result_scope = str(arg.scope)
+
+        if resource:
+            result_resource = str(resource)
+        if scope:
+            result_scope = str(scope)
+
+        return UMA_Permission(resource=result_resource, scope=result_scope)
+
+
+class Resource(UMA_Permission):
+    def __init__(self, resource):
+        super().__init__(resource=resource)
+
+
+class Scope(UMA_Permission):
+    def __init__(self, scope):
+        super().__init__(scope=scope)


### PR DESCRIPTION
Allow Keycloak to directly evaluate the permissions of a token and decide whether the bearer of a given token should be granted access.