### PR TITLE
Require minimum urllib 1.26.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=['keycloak', 'keycloak.authorization', 'keycloak.tests'],
-    install_requires=['requests>=2.20.0', 'python-jose>=1.4.0'],
+    install_requires=['requests>=2.20.0', 'python-jose>=1.4.0', 'urllib>=1.26.0'],
     tests_require=['httmock>=1.2.5'],
     classifiers=[
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
We use an attribute (allowed_methods) from urllib which is 
only available since 1.26.0 so we should require this as minimum.

Issue: marcospereirampj#196