### PR TITLE
fix: Add missing keycloak.authorization package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     description="python-keycloak is a Python package providing access to the Keycloak API.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=["keycloak"],
+    packages=["keycloak", "keycloak.authorization"],
     install_requires=reqs,
     tests_require=dev_reqs,
     extras_require={"docs": docs_reqs},


### PR DESCRIPTION
Re-adds `keycloak.authorization` to the list of packages in setup.py so it gets included in wheels.

Fixes #311