### PR TITLE
test: Make curl silent

### DIFF
--- a/test_keycloak_init.sh
+++ b/test_keycloak_init.sh
@@ -14,7 +14,7 @@ function keycloak_start() {
     echo "Starting keycloak docker container"
     docker run -d --name unittest_keycloak -e KEYCLOAK_ADMIN="${KEYCLOAK_ADMIN}" -e KEYCLOAK_ADMIN_PASSWORD="${KEYCLOAK_ADMIN_PASSWORD}" -p "${KEYCLOAK_PORT}:8080" "${KEYCLOAK_DOCKER_IMAGE}" start-dev
     SECONDS=0
-    until curl localhost:$KEYCLOAK_PORT; do
+    until curl --silent --output /dev/null localhost:$KEYCLOAK_PORT; do
       sleep 5;
       if [ ${SECONDS} -gt 180 ]; then
         echo "Timeout exceeded";


### PR DESCRIPTION
Prevent curl complaining while keycloak is starting, and remove HTML dump