### PR TITLE
feat: Ability to set custom timeout for KeycloakOpenId and KeycloakAdmin

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -88,6 +88,7 @@ class KeycloakAdmin:
         custom_headers=None,
         user_realm_name=None,
         auto_refresh_token=None,
+        timeout=60,
     ):
         self.server_url = server_url
         self.username = username
@@ -100,6 +101,7 @@ class KeycloakAdmin:
         self.auto_refresh_token = auto_refresh_token or []
         self.user_realm_name = user_realm_name
         self.custom_headers = custom_headers
+        self.timeout = timeout
 
         # Get token Admin
         self.get_token()
@@ -2695,6 +2697,7 @@ class KeycloakAdmin:
             verify=self.verify,
             client_secret_key=self.client_secret_key,
             custom_headers=self.custom_headers,
+            timeout=self.timeout,
         )
 
         grant_type = []

--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -73,13 +73,14 @@ class KeycloakOpenID:
         verify=True,
         custom_headers=None,
         proxies=None,
+        timeout=60,
     ):
         self.client_id = client_id
         self.client_secret_key = client_secret_key
         self.realm_name = realm_name
         headers = custom_headers if custom_headers is not None else dict()
         self.connection = ConnectionManager(
-            base_url=server_url, headers=headers, timeout=60, verify=verify, proxies=proxies
+            base_url=server_url, headers=headers, timeout=timeout, verify=verify, proxies=proxies
         )
 
         self.authorization = Authorization()


### PR DESCRIPTION
This adds the ability to set a custom timeout for all requests sent by KeycloakOpenID and KeycloakAdmin.
Since KeycloakAdmin constructs an instance of KeycloakOpenID, its hard to modify that timeout (you still can by doing `keycloak_admin.keycloak_openid._connection._timeout = ...`)