### PR TITLE
docs: add timeout to docstring

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -57,6 +57,7 @@ class KeycloakAdmin:
     :param user_realm_name: The realm name of the user, if different from realm_name
     :param auto_refresh_token: list of methods that allows automatic token refresh.
         Ex: ['get', 'put', 'post', 'delete']
+    :param timeout: connection timeout in seconds
     """
 
     PAGE_SIZE = 100

--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -62,6 +62,7 @@ class KeycloakOpenID:
     :param verify: True if want check connection SSL
     :param custom_headers: dict of custom header to pass to each HTML request
     :param proxies: dict of proxies to sent the request by.
+    :param timeout: connection timeout in seconds
     """
 
     def __init__(


### PR DESCRIPTION
I forgot to add the timeout param to docstring in https://github.com/marcospereirampj/python-keycloak/pull/346