### PR TITLE
fix: Support the auth_url method called with scope & state params now

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ keycloak_openid = KeycloakOpenID(server_url="http://localhost:8080/auth/",
 # Get WellKnow
 config_well_known = keycloak_openid.well_known()
 
+# Get Code With Oauth Authorization Request
+auth_url = keycloak_openid.auth_url(
+    redirect_uri="your_call_back_url",
+    scope="email",
+    state="your_state_info")
+
+# Get Access Token With Code
+access_token = keycloak_openid.token(
+    grant_type='authorization_code',
+    code='the_code_you_get_from_auth_url_callback',
+    redirect_uri="your_call_back_url")
+
+
 # Get Token
 token = keycloak_openid.token("user", "password")
 token = keycloak_openid.token("user", "password", totp="012345")

--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -176,10 +176,16 @@ class KeycloakOpenID:
 
     def auth_url(self, redirect_uri, scope="email", state=""):
         """
+        Get authorization URL endpoint.
 
-        http://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint
-
-        :return:
+        :param redirect_uri: Redirect url to receive oauth code
+        :type redirect_uri: str
+        :param scope: Scope of authorization request, split with the blank space
+        :type: scope: str
+        :param state: State will be returned to the redirect_uri
+        :type: str
+        :returns: Authorization URL Full Build
+        :rtype: str
         """
         params_path = {
             "authorization-endpoint": self.well_known()["authorization_endpoint"],

--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -174,7 +174,7 @@ class KeycloakOpenID:
 
         return raise_error_from_response(data_raw, KeycloakGetError)
 
-    def auth_url(self, redirect_uri):
+    def auth_url(self, redirect_uri, scope="email", state=""):
         """
 
         http://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint
@@ -185,6 +185,8 @@ class KeycloakOpenID:
             "authorization-endpoint": self.well_known()["authorization_endpoint"],
             "client-id": self.client_id,
             "redirect-uri": redirect_uri,
+            "scope": scope,
+            "state": state,
         }
         return URL_AUTH.format(**params_path)
 

--- a/src/keycloak/urls_patterns.py
+++ b/src/keycloak/urls_patterns.py
@@ -32,6 +32,7 @@ URL_INTROSPECT = "realms/{realm-name}/protocol/openid-connect/token/introspect"
 URL_ENTITLEMENT = "realms/{realm-name}/authz/entitlement/{resource-server-id}"
 URL_AUTH = (
     "{authorization-endpoint}?client_id={client-id}&response_type=code&redirect_uri={redirect-uri}"
+    "&scope={scope}&state={state} "
 )
 
 # ADMIN URLS


### PR DESCRIPTION
We need the standard Oauth 2.0 Protocols 's scope & state params to allow the most import function!
the oauth 2.0 docs: 
> https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint
```
scope
REQUIRED. OpenID Connect requests MUST contain the openid scope value. If the openid scope value is not present, the behavior is entirely unspecified. Other scope values MAY be present. Scope values used that are not understood by an implementation SHOULD be ignored. See Sections [5.4](https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims) and [11](https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess) for additional scope values defined by this specification.
state
RECOMMENDED. Opaque value used to maintain state between the request and the callback. Typically, Cross-Site Request Forgery (CSRF, XSRF) mitigation is done by cryptographically binding the value of this parameter with a browser cookie.
```
that's important
