### PR TITLE
fix: check client existence based on clientId

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -1046,19 +1046,19 @@ class KeycloakAdmin:
         data_raw = self.raw_get(urls_patterns.URL_ADMIN_CLIENT.format(**params_path))
         return raise_error_from_response(data_raw, KeycloakGetError)
 
-    def get_client_id(self, client_name):
+    def get_client_id(self, client_id):
         """Get internal keycloak client id from client-id.
 
         This is required for further actions against this client.
 
-        :param client_name: name in ClientRepresentation
+        :param client_id: clientId in ClientRepresentation
             https://www.keycloak.org/docs-api/18.0/rest-api/index.html#_clientrepresentation
         :return: client_id (uuid as string)
         """
         clients = self.get_clients()
 
         for client in clients:
-            if client_name == client.get("name") or client_name == client.get("clientId"):
+            if client_id == client.get("clientId"):
                 return client["id"]
 
         return None
@@ -1237,7 +1237,7 @@ class KeycloakAdmin:
         :return: Client ID
         """
         if skip_exists:
-            client_id = self.get_client_id(client_name=payload["name"])
+            client_id = self.get_client_id(client_id=payload["clientId"])
 
             if client_id is not None:
                 return client_id

--- a/tests/test_keycloak_admin.py
+++ b/tests/test_keycloak_admin.py
@@ -655,8 +655,8 @@ def test_clients(admin: KeycloakAdmin, realm: str):
     assert len(admin.get_clients()) == 7
 
     # Test get client id
-    assert admin.get_client_id(client_name="test-client") == client_id
-    assert admin.get_client_id(client_name="does-not-exist") is None
+    assert admin.get_client_id(client_id="test-client") == client_id
+    assert admin.get_client_id(client_id="does-not-exist") is None
 
     # Test update client
     res = admin.update_client(client_id=client_id, payload={"name": "test-client-change"})
@@ -856,7 +856,7 @@ def test_clients(admin: KeycloakAdmin, realm: str):
     assert err.match('404: b\'{"error":"Could not find client"}\'')
 
     secrets = admin.get_client_secrets(
-        client_id=admin.get_client_id(client_name="test-confidential")
+        client_id=admin.get_client_id(client_id="test-confidential")
     )
     assert secrets == {"type": "secret", "value": "test-secret"}
 
@@ -865,11 +865,11 @@ def test_clients(admin: KeycloakAdmin, realm: str):
     assert err.match('404: b\'{"error":"Could not find client"}\'')
 
     res = admin.generate_client_secrets(
-        client_id=admin.get_client_id(client_name="test-confidential")
+        client_id=admin.get_client_id(client_id="test-confidential")
     )
     assert res
     assert (
-        admin.get_client_secrets(client_id=admin.get_client_id(client_name="test-confidential"))
+        admin.get_client_secrets(client_id=admin.get_client_id(client_id="test-confidential"))
         == res
     )
 

--- a/tests/test_keycloak_openid.py
+++ b/tests/test_keycloak_openid.py
@@ -163,10 +163,10 @@ def test_exchange_token(
     admin.realm_name = oid.realm_name
     admin.assign_client_role(
         user_id=admin.get_user_id(username=username),
-        client_id=admin.get_client_id(client_name="realm-management"),
+        client_id=admin.get_client_id(client_id="realm-management"),
         roles=[
             admin.get_client_role(
-                client_id=admin.get_client_id(client_name="realm-management"),
+                client_id=admin.get_client_id(client_id="realm-management"),
                 role_name="impersonation",
             )
         ],


### PR DESCRIPTION
Remove the necessity for supplying client name for create a new client
request, also don't check existing clients based on client name as those
can be duplicate

BREAKING CHANGE: Renamed parameter client_name to client_id in get_client_id method

Closes #351