### PR TITLE
feat: add client scope-mappings client roles operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,17 @@ keycloak_admin.get_realm_roles_of_client_scope(client_id=client_id)
 # Remove realm roles assigned to client's scope
 keycloak_admin.delete_realm_roles_of_client_scope(client_id=client_id, roles=realm_roles)
 
+another_client_id = keycloak_admin.get_client_id("my-client-2")
+
+# Assign client roles to client's scope
+keycloak_admin.assign_client_roles_to_client_scope(client_id=another_client_id, client_roles_owner_id=client_id, roles=client_roles)
+
+# Get client roles assigned to client's scope
+keycloak_admin.get_client_roles_of_client_scope(client_id=another_client_id, client_roles_owner_id=client_id)
+
+# Remove client roles assigned to client's scope
+keycloak_admin.delete_client_roles_of_client_scope(client_id=another_client_id, client_roles_owner_id=client_id, roles=client_roles)
+
 # Get all ID Providers
 idps = keycloak_admin.get_idps()
 

--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -1639,6 +1639,63 @@ class KeycloakAdmin:
         )
         return raise_error_from_response(data_raw, KeycloakGetError)
 
+    def assign_client_roles_to_client_scope(self, client_id, client_roles_owner_id, roles):
+        """Assign client roles to a client's scope.
+
+        :param client_id: id of client (not client-id) who is assigned the roles
+        :param client_roles_owner_id: id of client (not client-id) who has the roles
+        :param roles: roles list or role (use RoleRepresentation)
+        :return: Keycloak server response
+        """
+        payload = roles if isinstance(roles, list) else [roles]
+        params_path = {
+            "realm-name": self.realm_name,
+            "id": client_id,
+            "client": client_roles_owner_id,
+        }
+        data_raw = self.raw_post(
+            urls_patterns.URL_ADMIN_CLIENT_SCOPE_MAPPINGS_CLIENT_ROLES.format(**params_path),
+            data=json.dumps(payload),
+        )
+        return raise_error_from_response(data_raw, KeycloakPostError, expected_codes=[204])
+
+    def delete_client_roles_of_client_scope(self, client_id, client_roles_owner_id, roles):
+        """Delete client roles of a client's scope.
+
+        :param client_id: id of client (not client-id) who is assigned the roles
+        :param client_roles_owner_id: id of client (not client-id) who has the roles
+        :param roles: roles list or role (use RoleRepresentation)
+        :return: Keycloak server response
+        """
+        payload = roles if isinstance(roles, list) else [roles]
+        params_path = {
+            "realm-name": self.realm_name,
+            "id": client_id,
+            "client": client_roles_owner_id,
+        }
+        data_raw = self.raw_delete(
+            urls_patterns.URL_ADMIN_CLIENT_SCOPE_MAPPINGS_CLIENT_ROLES.format(**params_path),
+            data=json.dumps(payload),
+        )
+        return raise_error_from_response(data_raw, KeycloakDeleteError, expected_codes=[204])
+
+    def get_client_roles_of_client_scope(self, client_id, client_roles_owner_id):
+        """Get all client roles for a client's scope.
+
+        :param client_id: id of client (not client-id)
+        :param client_roles_owner_id: id of client (not client-id) who has the roles
+        :return: Keycloak server response (array RoleRepresentation)
+        """
+        params_path = {
+            "realm-name": self.realm_name,
+            "id": client_id,
+            "client": client_roles_owner_id,
+        }
+        data_raw = self.raw_get(
+            urls_patterns.URL_ADMIN_CLIENT_SCOPE_MAPPINGS_CLIENT_ROLES.format(**params_path)
+        )
+        return raise_error_from_response(data_raw, KeycloakGetError)
+
     def assign_realm_roles(self, user_id, roles):
         """Assign realm roles to a user.
 

--- a/src/keycloak/urls_patterns.py
+++ b/src/keycloak/urls_patterns.py
@@ -92,6 +92,9 @@ URL_ADMIN_CLIENT_ROLE_MEMBERS = URL_ADMIN_CLIENT + "/roles/{role-name}/users"
 URL_ADMIN_CLIENT_ROLE_GROUPS = URL_ADMIN_CLIENT + "/roles/{role-name}/groups"
 URL_ADMIN_CLIENT_MANAGEMENT_PERMISSIONS = URL_ADMIN_CLIENT + "/management/permissions"
 URL_ADMIN_CLIENT_SCOPE_MAPPINGS_REALM_ROLES = URL_ADMIN_CLIENT + "/scope-mappings/realm"
+URL_ADMIN_CLIENT_SCOPE_MAPPINGS_CLIENT_ROLES = (
+    URL_ADMIN_CLIENT + "/scope-mappings/clients/{client}"
+)
 
 URL_ADMIN_CLIENT_AUTHZ_SETTINGS = URL_ADMIN_CLIENT + "/authz/resource-server/settings"
 URL_ADMIN_CLIENT_AUTHZ_RESOURCES = URL_ADMIN_CLIENT + "/authz/resource-server/resource?max=-1"


### PR DESCRIPTION
Add client-level roles to the client’s scope

POST /{realm}/client-scopes/{id}/scope-mappings/clients/{client}

Get the roles associated with a client’s scope Returns roles for the client.

GET /{realm}/client-scopes/{id}/scope-mappings/clients/{client}


Remove client-level roles from the client’s scope.

DELETE /{realm}/client-scopes/{id}/scope-mappings/clients/{client}


Please let me know if you need anything to be changed.