### PR TITLE
feat: attack detection API implementation

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -3597,3 +3597,41 @@ class KeycloakAdmin:
             urls_patterns.URL_ADMIN_REQUIRED_ACTIONS_ALIAS.format(**params_path), data=payload
         )
         return raise_error_from_response(data_raw, KeycloakPutError)
+
+    def get_bruteforce_detection_status(self, user_id):
+        """Get bruteforce detection status for user.
+
+        :param user_id: User id
+        :type user_id: str
+        :return: Bruteforce status.
+        :rtype: dict
+        """
+        params_path = {"realm-name": self.realm_name, "id": user_id}
+        data_raw = self.raw_get(
+            urls_patterns.URL_ADMIN_ATTACK_DETECTION_USER.format(**params_path)
+        )
+        return raise_error_from_response(data_raw, KeycloakGetError)
+
+    def clear_bruteforce_attempts_for_user(self, user_id):
+        """Clear bruteforce attempts for user.
+
+        :param user_id: User id
+        :type user_id: str
+        :return: empty dictionary.
+        :rtype: dict
+        """
+        params_path = {"realm-name": self.realm_name, "id": user_id}
+        data_raw = self.raw_delete(
+            urls_patterns.URL_ADMIN_ATTACK_DETECTION_USER.format(**params_path)
+        )
+        return raise_error_from_response(data_raw, KeycloakDeleteError)
+
+    def clear_all_bruteforce_attempts(self):
+        """Clear bruteforce attempts for all users in realm.
+
+        :return: empty dictionary.
+        :rtype: dict
+        """
+        params_path = {"realm-name": self.realm_name}
+        data_raw = self.raw_delete(urls_patterns.URL_ADMIN_ATTACK_DETECTION.format(**params_path))
+        return raise_error_from_response(data_raw, KeycloakDeleteError)

--- a/src/keycloak/urls_patterns.py
+++ b/src/keycloak/urls_patterns.py
@@ -195,3 +195,8 @@ URL_ADMIN_CLIENT_ROLE_CHILDREN = (
 URL_ADMIN_CLIENT_CERT_UPLOAD = URL_ADMIN_CLIENT_CERTS + "/upload-certificate"
 URL_ADMIN_REQUIRED_ACTIONS = URL_ADMIN_REALM + "/authentication/required-actions"
 URL_ADMIN_REQUIRED_ACTIONS_ALIAS = URL_ADMIN_REQUIRED_ACTIONS + "/{action-alias}"
+
+URL_ADMIN_ATTACK_DETECTION = "admin/realms/{realm-name}/attack-detection/brute-force/users"
+URL_ADMIN_ATTACK_DETECTION_USER = (
+    "admin/realms/{realm-name}/attack-detection/brute-force/users/{id}"
+)


### PR DESCRIPTION
This exposes the attack detection / bruteforce API in the admin client.
Tell me if you want me to combine the three tests into one, since they are mostly duplicates of each other.

This should address https://github.com/marcospereirampj/python-keycloak/issues/291, as well.