### PR TITLE
fix: CODEOWNERS clash with codeowner package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
     { include = "keycloak", from = "src/" },
     { include = "keycloak/**/*.py", from = "src/" },
 ]
-include = ["LICENSE", "CHANGELOG.md", "CODEOWNERS", "CONTRIBUTING.md"]
+include = ["LICENSE", "CHANGELOG.md", "CONTRIBUTING.md"]
 
 [tool.poetry.urls]
 Documentation = "https://python-keycloak.readthedocs.io/en/latest/"


### PR DESCRIPTION
## Bug 🐛 

Operating System: MacOS | Python 3.10.6

Including `"CODEOWNERS"` (along with `"LICENSE"`, `"CHANGELOG.md"`, etc.) in the `pyproject.toml` results in these being included in `site-packages` directory. This causes a conflict if there's an existing package installed with the same name as the one of the files.

### Concrete example

Have the package [codeowners](https://pypi.org/project/codeowners/) already installed (existing in `site-packages`).

Run `poetry add python-keycloak`

The following error happens:

```
Installing collected packages: python-keycloak
ERROR: Could not install packages due to an OSError: [Errno 1] Operation not permitted: '/Users/bob/Library/Caches/pypoetry/virtualenvs/some-repo/lib/python3.10/site-packages/CODEOWNERS'
```

## Fix 🔨 
The easy fix is to remove `CODEOWNERS` from `include`, which what I've done. You may wish to consider removing `include` entirely.
