### PR TITLE
Feature/exchange token

### DIFF
--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -28,6 +28,7 @@ class to handle authentication and token manipulation.
 """
 
 import json
+from typing import Optional
 
 from jose import jwt
 
@@ -341,9 +342,11 @@ class KeycloakOpenID:
     def exchange_token(
         self,
         token: str,
-        client_id: str,
         audience: str,
-        subject: str,
+        subject: Optional[str] = None,
+        subject_token_type: Optional[str] = None,
+        subject_issuer: Optional[str] = None,
+        requested_issuer: Optional[str] = None,
         requested_token_type: str = "urn:ietf:params:oauth:token-type:refresh_token",
         scope: str = "openid",
     ) -> dict:
@@ -354,12 +357,16 @@ class KeycloakOpenID:
 
         :param token: Access token
         :type token: str
-        :param client_id: Client id
-        :type client_id: str
         :param audience: Audience
         :type audience: str
         :param subject: Subject
         :type subject: str
+        :param subject_token_type: Token Type specification
+        :type subject_token_type: Optional[str]
+        :param subject_issuer: Issuer
+        :type subject_issuer: Optional[str]
+        :param requested_issuer: Issuer
+        :type requested_issuer: Optional[str]
         :param requested_token_type: Token type specification
         :type requested_token_type: str
         :param scope: Scope, defaults to openid
@@ -370,11 +377,14 @@ class KeycloakOpenID:
         params_path = {"realm-name": self.realm_name}
         payload = {
             "grant_type": ["urn:ietf:params:oauth:grant-type:token-exchange"],
-            "client_id": client_id,
+            "client_id": self.client_id,
             "subject_token": token,
+            "subject_token_type": subject_token_type,
+            "subject_issuer": subject_issuer,
             "requested_token_type": requested_token_type,
             "audience": audience,
             "requested_subject": subject,
+            "requested_issuer": requested_issuer,
             "scope": scope,
         }
         payload = self._add_secret_key(payload)

--- a/tests/test_keycloak_openid.py
+++ b/tests/test_keycloak_openid.py
@@ -210,7 +210,6 @@ def test_exchange_token(
     # Exchange token with the new user
     new_token = oid.exchange_token(
         token=token["access_token"],
-        client_id=oid.client_id,
         audience=oid.client_id,
         subject=username,
     )


### PR DESCRIPTION
# Suggesting improvements to exchange token feature

I've been using the exchange token feature of Keycloak. While trying to use this library I ran into an issue, I couldn't pass the requested_issuer field. This is a requirement when exchanging the access token for an IDP token. For this reason I decided to make some changes to the implementation which I'm suggesting to merge through this pull request.

## Suggested changes

- Add missing arguments, subject_token_type, subject_issuer and requested_issuer. These exist in the [specification](https://www.keycloak.org/docs/19.0.3/securing_apps/#_token-exchange) but were not possible to set. The requested_issuer is especially important to allow exchanging for an IDP token

- Make some of the optional fields type's Optional and give them None for the default value

- Use the class's inner client_id instead of receiving it from the arguments. If the library user needs a token from a specific client (not the subject client) he should initialize an instance with that client

## Notes

It's not big changes but in my opinion it greatly improves the functionality of this feature in a way that takes full advantage of keycloak's full implementation. Anybody should be able to now exchange their access tokens for the IDP's tokens for example if you want Google's token you just need to do:
```
keycloak_openid.exchange_token(
    token=access_token,
    requested_token_type='urn:ietf:params:oauth:token-type:access_token',
    requested_issuer='google'
)
```

Let me know if you like the idea and if it's something you'd like to add to this package. I'll be eagerly awaiting all the constructive criticism of my contributions!