### PR TITLE
feat: implement cache clearing API

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -3890,3 +3890,39 @@ class KeycloakAdmin:
         params_path = {"realm-name": self.realm_name}
         data_raw = self.raw_delete(urls_patterns.URL_ADMIN_ATTACK_DETECTION.format(**params_path))
         return raise_error_from_response(data_raw, KeycloakDeleteError)
+
+    def clear_keys_cache(self):
+        """Clear keys cache.
+
+        :return: empty dictionary.
+        :rtype: dict
+        """
+        params_path = {"realm-name": self.realm_name}
+        data_raw = self.raw_post(
+            urls_patterns.URL_ADMIN_CLEAR_KEYS_CACHE.format(**params_path), data=""
+        )
+        return raise_error_from_response(data_raw, KeycloakPostError, expected_codes=[204])
+
+    def clear_realm_cache(self):
+        """Clear realm cache.
+
+        :return: empty dictionary.
+        :rtype: dict
+        """
+        params_path = {"realm-name": self.realm_name}
+        data_raw = self.raw_post(
+            urls_patterns.URL_ADMIN_CLEAR_REALM_CACHE.format(**params_path), data=""
+        )
+        return raise_error_from_response(data_raw, KeycloakPostError, expected_codes=[204])
+
+    def clear_user_cache(self):
+        """Clear user cache.
+
+        :return: empty dictionary.
+        :rtype: dict
+        """
+        params_path = {"realm-name": self.realm_name}
+        data_raw = self.raw_post(
+            urls_patterns.URL_ADMIN_CLEAR_USER_CACHE.format(**params_path), data=""
+        )
+        return raise_error_from_response(data_raw, KeycloakPostError, expected_codes=[204])

--- a/src/keycloak/urls_patterns.py
+++ b/src/keycloak/urls_patterns.py
@@ -210,6 +210,10 @@ URL_ADMIN_ATTACK_DETECTION_USER = (
     "admin/realms/{realm-name}/attack-detection/brute-force/users/{id}"
 )
 
+URL_ADMIN_CLEAR_KEYS_CACHE = URL_ADMIN_REALM + "/clear-keys-cache"
+URL_ADMIN_CLEAR_REALM_CACHE = URL_ADMIN_REALM + "/clear-realm-cache"
+URL_ADMIN_CLEAR_USER_CACHE = URL_ADMIN_REALM + "/clear-user-cache"
+
 
 # UMA URLS
 URL_UMA_WELL_KNOWN = URL_WELL_KNOWN_BASE + "/uma2-configuration"

--- a/tests/test_keycloak_admin.py
+++ b/tests/test_keycloak_admin.py
@@ -2595,3 +2595,42 @@ def test_realm_default_roles(admin: KeycloakAdmin, realm: str) -> None:
     with pytest.raises(KeycloakPostError) as err:
         admin.add_realm_default_roles(payload=[{"id": "bad id"}])
     assert err.match('404: b\'{"error":"Could not find composite role"}\'')
+
+
+def test_clear_keys_cache(realm: str, admin: KeycloakAdmin) -> None:
+    """Test clearing the keys cache.
+
+    :param realm: Realm name
+    :type realm: str
+    :param admin: Keycloak admin
+    :type admin: KeycloakAdmin
+    """
+    admin.realm_name = realm
+    res = admin.clear_keys_cache()
+    assert res == {}
+
+
+def test_clear_realm_cache(realm: str, admin: KeycloakAdmin) -> None:
+    """Test clearing the realm cache.
+
+    :param realm: Realm name
+    :type realm: str
+    :param admin: Keycloak admin
+    :type admin: KeycloakAdmin
+    """
+    admin.realm_name = realm
+    res = admin.clear_realm_cache()
+    assert res == {}
+
+
+def test_clear_user_cache(realm: str, admin: KeycloakAdmin) -> None:
+    """Test clearing the user cache.
+
+    :param realm: Realm name
+    :type realm: str
+    :param admin: Keycloak admin
+    :type admin: KeycloakAdmin
+    """
+    admin.realm_name = realm
+    res = admin.clear_user_cache()
+    assert res == {}


### PR DESCRIPTION
Adds three methods to `KeycloakAdmin` for clearing various caches:
* `clear_keys_cache`
* `clear_realm_cache`
* `clear_user_cache`