### PR TITLE
fix: bad typing

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -29,6 +29,7 @@
 import copy
 import json
 from builtins import isinstance
+from typing import Optional
 
 import deprecation
 from requests_toolbelt import MultipartEncoder
@@ -100,7 +101,7 @@ class KeycloakAdmin:
         user_realm_name=None,
         auto_refresh_token=None,
         timeout=60,
-        connection: KeycloakOpenIDConnection = None,
+        connection: Optional[KeycloakOpenIDConnection] = None,
     ):
         """Init method.
 


### PR DESCRIPTION
fix a bad typing which make VSCode complaining.

`connection: KeycloakOpenIDConnection | None = None` is the correct typing also, but only works with python 3.10+ 
so I did use the `Optional`

![スクリーンショット 2023-03-24 22 12 05](https://user-images.githubusercontent.com/10774721/227530327-ec69ff66-9c14-49e3-86cc-70d125da548f.png)

This library is bad typed in general, may better if we can to add some type check to improve it.