### PR TITLE
fix: Check if _s exists in ConnectionManager before deleting it

### DIFF
--- a/src/keycloak/connection.py
+++ b/src/keycloak/connection.py
@@ -86,7 +86,8 @@ class ConnectionManager(object):
 
     def __del__(self):
         """Del method."""
-        self._s.close()
+        if hasattr(self, "_s"):
+            self._s.close()
 
     @property
     def base_url(self):


### PR DESCRIPTION
Simple but ugly fix. A better option would be to move the `__init__` call in `KeycloakOpenIDConnection`, which is impossible due to custom_headers.

Fixes #423 