### PR TITLE
Fixes `Authorization.load_config`  breaking when a scope based permission is linked with anything other than a role based policy

### DIFF
--- a/src/keycloak/authorization/__init__.py
+++ b/src/keycloak/authorization/__init__.py
@@ -88,7 +88,8 @@ class Authorization:
 
                 if "applyPolicies" in pol["config"]:
                     for policy_name in ast.literal_eval(pol["config"]["applyPolicies"]):
-                        self.policies[policy_name].add_permission(permission)
+                        if self.policies.get(policy_name) is not None:
+                            self.policies[policy_name].add_permission(permission)
 
             if pol["type"] == "resource":
                 permission = Permission(


### PR DESCRIPTION
Fixes #445 