### PR TITLE
fix: do not swap realm for user_realm when logging in with a client service account

### DIFF
--- a/src/keycloak/openid_connection.py
+++ b/src/keycloak/openid_connection.py
@@ -298,8 +298,6 @@ class KeycloakOpenIDConnection(ConnectionManager):
 
         grant_type = []
         if self.client_secret_key:
-            if self.user_realm_name:
-                self.realm_name = self.user_realm_name
             grant_type.append("client_credentials")
         elif self.username and self.password:
             grant_type.append("password")


### PR DESCRIPTION
Solves #428 by not overwriting the realm when logging in with a client_id and client_secret to a different user_realm.