### PR TITLE
enh: improve performance of get_user_id

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -850,8 +850,8 @@ class KeycloakAdmin:
         :rtype: str
         """
         lower_user_name = username.lower()
-        users = self.get_users(query={"search": lower_user_name})
-        return next((user["id"] for user in users if user["username"] == lower_user_name), None)
+        users = self.get_users(query={"username": lower_user_name, "max": 1, "exact": True})
+        return users[0]["id"] if len(users) == 1 else None
 
     def get_user(self, user_id):
         """Get representation of the user.


### PR DESCRIPTION
This PR improves the performance of the `get_user_id` function by changing how to retrieve a user from a username:

- The previous implementation used the `users` endpoint by using the search query, which starts to be slow when you have thousands of users.
- The new implementation still uses the `users` endpoint, but it queries the endpoint by specifying the username parameter, a max of 1, and an exact, which is much faster.