### PR TITLE
feat: add missing get_realm_role_by_id to KeycloakAdmin

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -2526,6 +2526,23 @@ class KeycloakAdmin:
         )
         return raise_error_from_response(data_raw, KeycloakGetError)
 
+    def get_realm_role_by_id(self, role_id: str):
+        """Get realm role by role id.
+
+        RoleRepresentation
+        https://www.keycloak.org/docs-api/18.0/rest-api/index.html#_rolerepresentation
+
+        :param role_id: role's id, not name!
+        :type role_id: str
+        :return: role
+        :rtype: dict
+        """
+        params_path = {"realm-name": self.connection.realm_name, "role-id": role_id}
+        data_raw = self.connection.raw_get(
+            urls_patterns.URL_ADMIN_REALM_ROLES_ROLE_BY_ID.format(**params_path)
+        )
+        return raise_error_from_response(data_raw, KeycloakGetError)
+
     def update_realm_role(self, role_name, payload):
         """Update a role for the realm by name.
 

--- a/src/keycloak/urls_patterns.py
+++ b/src/keycloak/urls_patterns.py
@@ -147,6 +147,7 @@ URL_ADMIN_IDPS = "admin/realms/{realm-name}/identity-provider/instances"
 URL_ADMIN_IDP_MAPPERS = "admin/realms/{realm-name}/identity-provider/instances/{idp-alias}/mappers"
 URL_ADMIN_IDP_MAPPER_UPDATE = URL_ADMIN_IDP_MAPPERS + "/{mapper-id}"
 URL_ADMIN_IDP = "admin/realms/{realm-name}/identity-provider/instances/{alias}"
+URL_ADMIN_REALM_ROLES_ROLE_BY_ID = URL_ADMIN_REALM + "/roles-by-id/{role-id}"
 URL_ADMIN_REALM_ROLES_ROLE_BY_NAME = "admin/realms/{realm-name}/roles/{role-name}"
 URL_ADMIN_REALM_ROLES_COMPOSITE_REALM_ROLE = (
     "admin/realms/{realm-name}/roles/{role-name}/composites"

--- a/tests/test_keycloak_admin.py
+++ b/tests/test_keycloak_admin.py
@@ -1119,6 +1119,10 @@ def test_realm_roles(admin: KeycloakAdmin, realm: str):
     role_id_2 = admin.create_realm_role(payload={"name": "test-realm-role"}, skip_exists=True)
     assert role_id == role_id_2
 
+    # Test get realm role by its id
+    res = admin.get_realm_role_by_id(role_id)
+    assert res["name"] == "test-realm-role"
+
     # Test update realm role
     res = admin.update_realm_role(
         role_name="test-realm-role", payload={"name": "test-realm-role-update"}

--- a/tests/test_keycloak_admin.py
+++ b/tests/test_keycloak_admin.py
@@ -1120,6 +1120,7 @@ def test_realm_roles(admin: KeycloakAdmin, realm: str):
     assert role_id == role_id_2
 
     # Test get realm role by its id
+    role_id = admin.get_realm_role(role_name="test-realm-role")["id"]
     res = admin.get_realm_role_by_id(role_id)
     assert res["name"] == "test-realm-role"
 


### PR DESCRIPTION
Adds missing get_realm_role_by_id to KeycloakAdmin