### PR TITLE
fix: loosen requests-toolbelt dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ sphinx-rtd-theme = {version = "^1.0.0", optional = true}
 readthedocs-sphinx-ext = {version = "^2.1.9", optional = true}
 m2r2 = {version = "^0.3.2", optional = true}
 sphinx-autoapi = {version = "^2.0.0", optional = true}
-requests-toolbelt = ">=1.0.0"
+requests-toolbelt = "*"
 deprecation = ">=2.1.0"
 
 [tool.poetry.extras]


### PR DESCRIPTION
The "requests-toolbelt" library is only used for "MultipartEncoder" which has been part of the library since it's initial release.

This patch loosens up the requests-toolbelt dependency to allow for more flexible co-installability.