### PR TITLE
feat: add KeycloakAdmin.get_idp()

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,8 +337,11 @@ keycloak_admin.get_client_roles_of_client_scope(client_id=another_client_id, cli
 # Remove client roles assigned to client's scope
 keycloak_admin.delete_client_roles_of_client_scope(client_id=another_client_id, client_roles_owner_id=client_id, roles=client_roles)
 
-# Get all ID Providers
+# Get all IDP Providers
 idps = keycloak_admin.get_idps()
+
+# Get a specific IDP Provider, using its alias
+idp = keycloak_admin.get_idp("idp-alias")
 
 # Create a new Realm
 keycloak_admin.create_realm(payload={"realm": "demo"}, skip_exists=False)

--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -773,6 +773,23 @@ class KeycloakAdmin:
         data_raw = self.connection.raw_get(urls_patterns.URL_ADMIN_IDPS.format(**params_path))
         return raise_error_from_response(data_raw, KeycloakGetError)
 
+    def get_idp(self, idp_alias):
+        """Get IDP provider.
+
+        Get the representation of a specific IDP Provider.
+
+        IdentityProviderRepresentation
+        https://www.keycloak.org/docs-api/18.0/rest-api/index.html#_identityproviderrepresentation
+
+        :param: idp_alias: alias for IdP to get
+        :type idp_alias: str
+        :return: IdentityProviderRepresentation
+        :rtype: dict
+        """
+        params_path = {"realm-name": self.connection.realm_name, "alias": idp_alias}
+        data_raw = self.connection.raw_get(urls_patterns.URL_ADMIN_IDP.format(**params_path))
+        return raise_error_from_response(data_raw, KeycloakGetError)
+
     def delete_idp(self, idp_alias):
         """Delete an ID Provider.
 

--- a/tests/test_keycloak_admin.py
+++ b/tests/test_keycloak_admin.py
@@ -395,6 +395,18 @@ def test_idps(admin: KeycloakAdmin, realm: str):
     assert len(idps) == 1
     assert "github" == idps[0]["alias"]
 
+    # Test get idp
+    idp = admin.get_idp("github")
+    assert "github" == idp["alias"]
+    assert idp.get("config")
+    assert "test" == idp["config"]["clientId"]
+    assert "**********" == idp["config"]["clientSecret"]
+
+    # Test get idp fail
+    with pytest.raises(KeycloakGetError) as err:
+        admin.get_idp("does-not-exist")
+    assert err.match('404: b\'{"error":"HTTP 404 Not Found"}\'')
+
     # Test IdP update
     res = admin.update_idp(idp_alias="github", payload=idps[0])
 


### PR DESCRIPTION
Add the missing `get_idp(alias)` method. Note that the failing tests are the one from master (related to auth), the idp ones finish with success.