### PR TITLE
_version.py no longer uses pkg_resources to retrieve the version

### DIFF
--- a/src/keycloak/_version.py
+++ b/src/keycloak/_version.py
@@ -21,6 +21,6 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import pkg_resources
+from importlib import metadata
 
-__version__ = pkg_resources.get_distribution("python-keycloak").version
+__version__ = metadata.version("python-keycloak")


### PR DESCRIPTION
Switched from pkg_resources to importlib due to deprecation warnings.