### PR TITLE
fix: remove python3.7 from CI (because it's unsupported since june 2023)

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         keycloak-version: ["20.0", "21.0", "latest"]
     env:
       KEYCLOAK_DOCKER_IMAGE_TAG: ${{ matrix.keycloak-version }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         keycloak-version: ["20.0", "21.0", "latest"]
     needs:
       - check-commits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Documentation = "https://python-keycloak.readthedocs.io/en/latest/"
 "Issue tracker" = "https://github.com/marcospereirampj/python-keycloak/issues"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<4.0"
+python = ">=3.8,<4.0"
 requests = ">=2.20.0"
 python-jose = ">=3.3.0"
 mock = {version = "^4.0.3", optional = true}


### PR DESCRIPTION
Hello,

Since june 2023, Python 3.7 has been declared unsupported (https://devguide.python.org/versions/#unsupported-versions)

This PR remove it from CI and add the version Python 3.12 instead