### PR TITLE
fix: Add direct "setuptools" dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ Documentation = "https://python-keycloak.readthedocs.io/en/latest/"
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
+setuptools = "*"
 requests = ">=2.20.0"
 python-jose = ">=3.3.0"
 mock = {version = "^4.0.3", optional = true}


### PR DESCRIPTION
With Python 3.12 the `setuptools` is no longer enabled by default, which makes python-keycloak fail because of `pkg_resources`.
Similarly with Poetry 1.7.0, the `poetry install --sync` also removes the `setuptools`, which results in the same error

I am not sure which version is reasonable to depend on, so I added any for now.