### PR TITLE
feat: allows retrieval of realm and client level roles for a user

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -3000,6 +3000,20 @@ class KeycloakAdmin:
         )
         return raise_error_from_response(data_raw, KeycloakDeleteError, expected_codes=[204])
 
+    def get_all_roles_of_user(self, user_id):
+        """Get all level roles for a user.
+
+        :param user_id: id of user
+        :type user_id: str
+        :return: Keycloak server response (array RoleRepresentation)
+        :rtype: list
+        """
+        params_path = {"realm-name": self.connection.realm_name, "id": user_id}
+        data_raw = self.connection.raw_get(
+            urls_patterns.URL_ADMIN_USER_ALL_ROLES.format(**params_path)
+        )
+        return raise_error_from_response(data_raw, KeycloakGetError)
+
     def get_client_roles_of_user(self, user_id, client_id):
         """Get all client roles for a user.
 

--- a/src/keycloak/urls_patterns.py
+++ b/src/keycloak/urls_patterns.py
@@ -51,6 +51,7 @@ URL_ADMIN_SEND_UPDATE_ACCOUNT = "admin/realms/{realm-name}/users/{id}/execute-ac
 URL_ADMIN_SEND_VERIFY_EMAIL = "admin/realms/{realm-name}/users/{id}/send-verify-email"
 URL_ADMIN_RESET_PASSWORD = "admin/realms/{realm-name}/users/{id}/reset-password"
 URL_ADMIN_GET_SESSIONS = "admin/realms/{realm-name}/users/{id}/sessions"
+URL_ADMIN_USER_ALL_ROLES = "admin/realms/{realm-name}/users/{id}/role-mappings"
 URL_ADMIN_USER_CLIENT_ROLES = (
     "admin/realms/{realm-name}/users/{id}/role-mappings/clients/{client-id}"
 )


### PR DESCRIPTION
Adding method **get_all_roles_of_user** to KeycloakAdmin.
Adding **URL_ADMIN_USER_ALL_ROLES** to url_patterns

This PR adds the functionality of retrieving roles from realm and client levels for a user.
Within my team, we need to retrieve all of a user's clients roles.
Currently, the only way to do this is by looping through all clients in a realm and using the KeycloakAdmin.get_client_roles_of_user function. This method requires a lot of calls and is very time consuming in the case of a large number of clients.
Using the [GET /admin/realms/{realm}/users/{id}/role-mappings](https://www.keycloak.org/docs-api/22.0.1/rest-api/index.html#_get_adminrealmsrealmusersidrole_mappings) endpoint of the Keycloak REST API would meet our need with only one request.