### PR TITLE
fix: use grant type password with client secret

### DIFF
--- a/src/keycloak/openid_connection.py
+++ b/src/keycloak/openid_connection.py
@@ -311,10 +311,10 @@ class KeycloakOpenIDConnection(ConnectionManager):
         The admin token is then set in the `token` attribute.
         """
         grant_type = []
-        if self.client_secret_key:
-            grant_type.append("client_credentials")
-        elif self.username and self.password:
+        if self.username and self.password:
             grant_type.append("password")
+        elif self.client_secret_key:
+            grant_type.append("client_credentials")
 
         if grant_type:
             self.token = self.keycloak_openid.token(


### PR DESCRIPTION
When both user credentials and client credentials are supplied, this library used the grant_type=client_credentials. This fix will instead retrieve the token with grant_type=password, similar to the Keycloak admin CLI kcadm.sh.