### PR TITLE
feat: Add new method to retrieve the child groups of a specific group.

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -1307,6 +1307,28 @@ class KeycloakAdmin:
         data_raw = self.connection.raw_get(urls_patterns.URL_ADMIN_GROUP.format(**params_path))
         return raise_error_from_response(data_raw, KeycloakGetError)
 
+    def get_child_groups(self, group_id, query=None):
+        """Get child groups by parent id.
+
+        Returns a list of groups who are children of group with id
+
+        GroupRepresentation
+        https://www.keycloak.org/docs-api/18.0/rest-api/#_grouprepresentation
+
+        :param group_id: The group id
+        :type group_id: str
+        :return: Keycloak server response (GroupRepresentation)
+        :rtype: list
+        """
+        query = query or {}
+        params_path = {"realm-name": self.connection.realm_name, "id": group_id}
+        url = urls_patterns.URL_ADMIN_GROUP_CHILD.format(**params_path)
+
+        if "first" in query or "max" in query:
+            return self.__fetch_paginated(url, query)
+
+        return self.__fetch_all(url, query)
+
     def get_subgroups(self, group, path):
         """Get subgroups.
 

--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -1317,6 +1317,8 @@ class KeycloakAdmin:
 
         :param group_id: The group id
         :type group_id: str
+        :param query: Additional query options
+        :type query: dict
         :return: Keycloak server response (GroupRepresentation)
         :rtype: list
         """
@@ -1344,14 +1346,15 @@ class KeycloakAdmin:
         :return: Keycloak server response (GroupRepresentation)
         :rtype: dict
         """
-        for subgroup in group["subGroups"]:
-            if subgroup["path"] == path:
-                return subgroup
-            elif subgroup["subGroups"]:
-                for subgroup in group["subGroups"]:
-                    result = self.get_subgroups(subgroup, path)
-                    if result:
-                        return result
+        if group.get("subGroups") is not None:
+            for subgroup in group["subGroups"]:
+                if subgroup["path"] == path:
+                    return subgroup
+                elif subgroup.get("subGroups") is not None and subgroup["subGroups"]:
+                    for subgroup in group["subGroups"]:
+                        result = self.get_subgroups(subgroup, path)
+                        if result:
+                            return result
         # went through the tree without hits
         return None
 

--- a/tests/test_keycloak_admin.py
+++ b/tests/test_keycloak_admin.py
@@ -690,7 +690,8 @@ def test_groups(admin: KeycloakAdmin, user: str):
 
     # Create 1 more subgroup
     subsubgroup_id_1 = admin.create_group(payload={"name": "subsubgroup-1"}, parent=subgroup_id_2)
-    main_group = admin.get_group(group_id=group_id)
+    main_group = admin.get_groups(query={"q": "%"})[0]
+    assert main_group["id"] == group_id
 
     # Test nested searches
     res = admin.get_subgroups(group=main_group, path="/main-group/subgroup-2/subsubgroup-1")

--- a/tests/test_keycloak_admin.py
+++ b/tests/test_keycloak_admin.py
@@ -660,15 +660,21 @@ def test_groups(admin: KeycloakAdmin, user: str):
     # Test get groups again
     groups = admin.get_groups()
     assert len(groups) == 1, groups
-    assert len(groups[0]["subGroups"]) == 2, groups["subGroups"]
+    assert groups[0]["subGroupCount"] == 2, groups["subGroupCount"]
     assert groups[0]["id"] == group_id
-    assert {x["id"] for x in groups[0]["subGroups"]} == {subgroup_id_1, subgroup_id_2}
+    sub_groups = admin.get_child_groups(groups[0]["id"])
+    assert {x["id"] for x in sub_groups} == {subgroup_id_1, subgroup_id_2}
 
     # Test get groups query
     groups = admin.get_groups(query={"max": 10})
     assert len(groups) == 1, groups
+    assert groups[0]["subGroupCount"] == 2, groups["subGroupCount"]
+
+    # Test get all groups query
+    groups = admin.get_groups(query={"q": "%"})
+    assert len(groups) == 1, groups
+    assert groups[0]["subGroupCount"] == 2, groups["subGroupCount"]
     assert len(groups[0]["subGroups"]) == 2, groups["subGroups"]
-    assert groups[0]["id"] == group_id
     assert {x["id"] for x in groups[0]["subGroups"]} == {subgroup_id_1, subgroup_id_2}
 
     # Test get group


### PR DESCRIPTION
This pull request is in response to issue #509 and the changes introduced to keycloak 23. 
According to [this comment](https://github.com/keycloak/keycloak/issues/25053#issuecomment-1888535340) the new expected way to retrieve subgroups is to use the groups/{id}/children endpoint. 

This pr adds a new method which uses the children endpoint to fetch the children of the specified group.
I also tried to fix the remaining test cases that were failing in tests/test_keycloak_admin.py::test_groups. 
Tough I am not sure if that is the way you would want it fixed so any feedback there is appreciated as with the rest is appreciated. 