### PR TITLE
refactor: incorporate custom headers into default header setup

### DIFF
--- a/src/keycloak/openid_connection.py
+++ b/src/keycloak/openid_connection.py
@@ -300,6 +300,7 @@ class KeycloakOpenIDConnection(ConnectionManager):
                 verify=self.verify,
                 client_secret_key=self.client_secret_key,
                 timeout=self.timeout,
+                custom_headers=self.custom_headers,
             )
 
         return self._keycloak_openid

--- a/src/keycloak/openid_connection.py
+++ b/src/keycloak/openid_connection.py
@@ -124,7 +124,7 @@ class KeycloakOpenIDConnection(ConnectionManager):
             self.headers = {
                 **self.headers,
                 "Authorization": "Bearer " + self.token.get("access_token"),
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
             }
 
         super().__init__(

--- a/src/keycloak/openid_connection.py
+++ b/src/keycloak/openid_connection.py
@@ -114,19 +114,18 @@ class KeycloakOpenIDConnection(ConnectionManager):
         self.client_secret_key = client_secret_key
         self.user_realm_name = user_realm_name
         self.timeout = timeout
+        self.headers = {}
+        self.custom_headers = custom_headers
 
         if self.token is None:
             self.get_token()
 
-        self.headers = (
-            {
+        if self.token is not None:
+            self.headers = {
+                **self.headers,
                 "Authorization": "Bearer " + self.token.get("access_token"),
-                "Content-Type": "application/json",
+                "Content-Type": "application/json"
             }
-            if self.token is not None
-            else {}
-        )
-        self.custom_headers = custom_headers
 
         super().__init__(
             base_url=self.server_url, headers=self.headers, timeout=60, verify=self.verify


### PR DESCRIPTION
Hi this is my first contribution to this project, and I hope I'm doing this right. If there's anything I've missed or any additional information you need, please let me know.

## Overview
Refactor of `KeycloakOpenIDConnection`, setting `headers` and `custom_headers` before any web request requiring any custom headers. This allows custom headers like Cloudflare access tokens to be included in the initial `get_token()` request.

## Changes
This pull request refactors how default headers are set up. I've made modifications to ensure that custom headers, when provided, are incorporated correctly before any web requests. 

The key changes include:
- The custom headers are merged before the `self.get_token()` method is called.
- Ensuring that custom headers such as Cloudflare access tokens are included in all requests.
- Maintaining the default headers like `'Authorization'` and `'Content-Type'`, ensuring they are not overwritten.

## Reason
The motivation behind these changes is to ensure custom headers are available before any web requests requiring headers are made. This was a particular error when using `KeycloakOpenIDConnection` for `KeycloakAdmin`. 