### PR TITLE
feat: Allow query parameters for group children

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -1349,21 +1349,24 @@ class KeycloakAdmin:
         # went through the tree without hits
         return None
 
-    def get_group_children(self, group_id):
-        """Get group children by id.
+    def get_group_children(self, group_id, query=None):
+        """Get group children by parent id.
 
         Returns full group children details
 
-        :param group_id: The group id
+        :param group_id: The parent group id
         :type group_id: str
+        :param query: Additional query options
+        :type query: dict
         :return: Keycloak server response (GroupRepresentation)
         :rtype: dict
         """
+        query = query or {}
         params_path = {"realm-name": self.connection.realm_name, "id": group_id}
-        data_raw = self.connection.raw_get(
-            urls_patterns.URL_ADMIN_GROUP_CHILD.format(**params_path)
-        )
-        return raise_error_from_response(data_raw, KeycloakGetError)
+        url = urls_patterns.URL_ADMIN_GROUP_CHILD.format(**params_path)
+        if "first" in query or "max" in query:
+            return self.__fetch_paginated(url, query)
+        return self.__fetch_all(url, query)
 
     def get_group_members(self, group_id, query=None):
         """Get members by group id.


### PR DESCRIPTION
Allow query parameters on `get_group_children` for pagination and briefRepresentation.