### PR TITLE
fix: get_groups pagination not working #537

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -1287,7 +1287,8 @@ class KeycloakAdmin:
 
         if "first" in query or "max" in query:
             groups = self.__fetch_paginated(url, query)
-        groups = self.__fetch_all(url, query)
+        else:
+            groups = self.__fetch_all(url, query)
 
         # For version +23.0.0
         for group in groups:


### PR DESCRIPTION
Issue Link: https://github.com/marcospereirampj/python-keycloak/issues/537
Why: 
When calling the get_groups method with parameters for "first" and "max" to limit the number of results, it seems that these parameters are not being respected. Instead, the method returns all the groups for the realm, regardless of the specified pagination values.

What:
normal call was modifying pagination call everytime.