### PR TITLE
fix: keycloak_admin.create_user documentation/ typehint

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -857,8 +857,8 @@ class KeycloakAdmin:
             Otherwise, return existing user ID.
         :type exist_ok: bool
 
-        :return: UserRepresentation
-        :rtype: dict
+        :return: user_id
+        :rtype: str
         """
         params_path = {"realm-name": self.connection.realm_name}
 


### PR DESCRIPTION
the type hint / return value was incorrect, the method returns user_id, of type: str 
here is the fix for this.

refers to issue: 
https://github.com/marcospereirampj/python-keycloak/issues/421
https://github.com/marcospereirampj/python-keycloak/issues/544