### PR TITLE
Updated KeycloakOpenID documentation about server_url

### DIFF
--- a/docs/source/modules/openid_client.rst
+++ b/docs/source/modules/openid_client.rst
@@ -12,6 +12,7 @@ Configure client OpenID
     from keycloak import KeycloakOpenID
 
     # Configure client
+    # For KeyCloak 17+ the server url must be something like "http://localhost:8080" without "/auth"
     keycloak_openid = KeycloakOpenID(server_url="http://localhost:8080/auth/",
                                      client_id="example_client",
                                      realm_name="example_realm",


### PR DESCRIPTION
For KeyCloak 17+ the authentication url changed, is not necessary to add "/auth" at the end of the url because this will throw a 404 error.