### PR TITLE
Fix Handling of Optional Query Parameters in `a_send_update_account` and `a_send_verify_email`

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -5073,7 +5073,7 @@ class KeycloakAdmin:
         data_raw = await self.connection.a_raw_put(
             urls_patterns.URL_ADMIN_SEND_UPDATE_ACCOUNT.format(**params_path),
             data=json.dumps(payload),
-            kwargs=params_query,
+            **params_query,
         )
         return raise_error_from_response(data_raw, KeycloakPutError)
 
@@ -5097,7 +5097,7 @@ class KeycloakAdmin:
         data_raw = await self.connection.a_raw_put(
             urls_patterns.URL_ADMIN_SEND_VERIFY_EMAIL.format(**params_path),
             data={},
-            kwargs=params_query,
+            **params_query,
         )
         return raise_error_from_response(data_raw, KeycloakPutError)
 


### PR DESCRIPTION
Hi, first of all, thanks for this great project!

This pull request addresses the issue of incorrect handling of optional query parameters in the new async methods `a_send_update_account` and `a_send_verify_email`. 

Currently, when awaiting `a_send_update_account` with parameters such as:

```python
a_send_update_account(user_id="a48ac290-8846-4224-b5dd-e5c69ecf8754", payload=["UPDATE_PASSWORD"], client_id="some-client", redirect_uri="https://some.redirect.url")
```

The resulting request URL contains one query param `kwargs` with the real query params formatted as the value:

```
https://auth.example.com/admin/realms/a-realm/users/a48ac290-8846-4224-b5dd-e5c69ecf8754/execute-actions-email?kwargs=%7B%27client_id%27%3A%20%27some-client%27%2C%20%27lifespan%27%3A%20None%2C%20%27redirect_uri%27%3A%20%27https%3A%2F%2Fsome.redirect.url
```

With that URL, the optional query parameters are practically ignored by Keycloak. A difference between `httpx` and `requests` also exist in the handling of query params with the value `None`, which are included in `httpx` as-is https://www.python-httpx.org/compatibility/#query-parameters:~:text=than%20urllib3.-,Query%20Parameters,-requests%20omits%20params. This caused an error in another test, so I have unified the behaviour by explicitly filtering query params before passing them to httpx

The current tests for these email methods are somewhat limited, so I've added a test that checks for interaction with the underlying `httpx` connection instead.