### PR TITLE
feat: add matchingUri support for listing resources with wildcards

### DIFF
--- a/src/keycloak/keycloak_uma.py
+++ b/src/keycloak/keycloak_uma.py
@@ -210,6 +210,7 @@ class KeycloakUMA:
         owner: str = "",
         resource_type: str = "",
         scope: str = "",
+        matchingUri: bool = False,
         first: int = 0,
         maximum: int = -1,
     ):
@@ -230,6 +231,8 @@ class KeycloakUMA:
         :type resource_type: str
         :param scope: query resource scope
         :type scope: str
+        :param matchingUri: enable URI matching
+        :type matchingUri: bool
         :param first: index of first matching resource to return
         :type first: int
         :param maximum: maximum number of resources to return (-1 for all)
@@ -250,6 +253,8 @@ class KeycloakUMA:
             query["type"] = resource_type
         if scope:
             query["scope"] = scope
+        if matchingUri:
+            query["matchingUri"] = "true"
         if first > 0:
             query["first"] = first
         if maximum >= 0:
@@ -544,6 +549,7 @@ class KeycloakUMA:
         owner: str = "",
         resource_type: str = "",
         scope: str = "",
+        matchingUri: bool = False,
         first: int = 0,
         maximum: int = -1,
     ):
@@ -565,6 +571,8 @@ class KeycloakUMA:
         :param scope: query resource scope
         :type scope: str
         :param first: index of first matching resource to return
+        :param matchingUri: enable URI matching
+        :type matchingUri: bool
         :type first: int
         :param maximum: maximum number of resources to return (-1 for all)
         :type maximum: int
@@ -584,6 +592,8 @@ class KeycloakUMA:
             query["type"] = resource_type
         if scope:
             query["scope"] = scope
+        if matchingUri:
+            query["matchingUri"] = "true"
         if first > 0:
             query["first"] = first
         if maximum >= 0:

--- a/tests/test_keycloak_uma.py
+++ b/tests/test_keycloak_uma.py
@@ -109,7 +109,8 @@ def test_uma_resource_sets(uma: KeycloakUMA):
     assert len(resource_set_list_ids) == 0
     # With matchingUri query option
     resource_set_list_ids = uma.resource_set_list_ids(
-        uri="/some_resources/resource", matchingUri=True)
+        uri="/some_resources/resource", matchingUri=True
+    )
     assert len(resource_set_list_ids) == 1
 
     # Test create the same resource set

--- a/tests/test_keycloak_uma.py
+++ b/tests/test_keycloak_uma.py
@@ -96,11 +96,21 @@ def test_uma_resource_sets(uma: KeycloakUMA):
         "name": "mytest",
         "scopes": ["test:read", "test:write"],
         "type": "urn:test",
+        "uris": ["/some_resources/*"],
     }
     created_resource = uma.resource_set_create(resource_to_create)
     assert created_resource
     assert created_resource["_id"], created_resource
     assert set(resource_to_create).issubset(set(created_resource)), created_resource
+
+    # Test getting resource with wildcard
+    # Without matchingUri query option
+    resource_set_list_ids = uma.resource_set_list_ids(uri="/some_resources/resource")
+    assert len(resource_set_list_ids) == 0
+    # With matchingUri query option
+    resource_set_list_ids = uma.resource_set_list_ids(
+        uri="/some_resources/resource", matchingUri=True)
+    assert len(resource_set_list_ids) == 1
 
     # Test create the same resource set
     with pytest.raises(KeycloakPostError) as err:
@@ -382,11 +392,22 @@ async def test_a_uma_resource_sets(uma: KeycloakUMA):
         "name": "mytest",
         "scopes": ["test:read", "test:write"],
         "type": "urn:test",
+        "uris": ["/some_resources/*"],
     }
     created_resource = await uma.a_resource_set_create(resource_to_create)
     assert created_resource
     assert created_resource["_id"], created_resource
     assert set(resource_to_create).issubset(set(created_resource)), created_resource
+
+    # Test getting resource with wildcard
+    # Without matchingUri query option
+    resource_set_list_ids = await uma.a_resource_set_list_ids(uri="/some_resources/resource")
+    assert len(resource_set_list_ids) == 0
+    # With matchingUri query option
+    resource_set_list_ids = await uma.a_resource_set_list_ids(
+        uri="/some_resources/resource", matchingUri=True
+    )
+    assert len(resource_set_list_ids) == 1
 
     # Test create the same resource set
     with pytest.raises(KeycloakPostError) as err:


### PR DESCRIPTION
Fixes #587 
Adds matchingUri boolean option for resource_set_list_id and a_resource_set_list_id to query for resources with URIs with wildcards.