### PR TITLE
Set client_credentials as grant_type also when x509 certificate is given

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -86,6 +86,7 @@ class KeycloakAdmin:
     def __init__(
         self,
         server_url=None,
+        grant_type=None,
         username=None,
         password=None,
         token=None,
@@ -104,6 +105,8 @@ class KeycloakAdmin:
 
         :param server_url: Keycloak server url
         :type server_url: str
+        :param grant_type: grant type for authn
+        :type grant_type: str
         :param username: admin username
         :type username: str
         :param password: admin password
@@ -136,6 +139,7 @@ class KeycloakAdmin:
         """
         self.connection = connection or KeycloakOpenIDConnection(
             server_url=server_url,
+            grant_type=grant_type,
             username=username,
             password=password,
             token=token,

--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -276,7 +276,7 @@ class KeycloakOpenID:
         self,
         username="",
         password="",
-        grant_type=["password"],
+        grant_type="password",
         code="",
         redirect_uri="",
         totp=None,
@@ -338,7 +338,7 @@ class KeycloakOpenID:
         )
         return raise_error_from_response(data_raw, KeycloakPostError)
 
-    def refresh_token(self, refresh_token, grant_type=["refresh_token"]):
+    def refresh_token(self, refresh_token, grant_type="refresh_token"):
         """Refresh the user token.
 
         The token endpoint is used to obtain tokens. Tokens can either be obtained by
@@ -409,7 +409,7 @@ class KeycloakOpenID:
         """
         params_path = {"realm-name": self.realm_name}
         payload = {
-            "grant_type": ["urn:ietf:params:oauth:grant-type:token-exchange"],
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
             "client_id": self.client_id,
             "subject_token": token,
             "subject_token_type": subject_token_type,
@@ -920,7 +920,7 @@ class KeycloakOpenID:
         self,
         username="",
         password="",
-        grant_type=["password"],
+        grant_type="password",
         code="",
         redirect_uri="",
         totp=None,
@@ -982,7 +982,7 @@ class KeycloakOpenID:
         )
         return raise_error_from_response(data_raw, KeycloakPostError)
 
-    async def a_refresh_token(self, refresh_token, grant_type=["refresh_token"]):
+    async def a_refresh_token(self, refresh_token, grant_type="refresh_token"):
         """Refresh the user token asynchronously.
 
         The token endpoint is used to obtain tokens. Tokens can either be obtained by
@@ -1053,7 +1053,7 @@ class KeycloakOpenID:
         """
         params_path = {"realm-name": self.realm_name}
         payload = {
-            "grant_type": ["urn:ietf:params:oauth:grant-type:token-exchange"],
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
             "client_id": self.client_id,
             "subject_token": token,
             "subject_token_type": subject_token_type,

--- a/src/keycloak/openid_connection.py
+++ b/src/keycloak/openid_connection.py
@@ -157,6 +157,19 @@ class KeycloakOpenIDConnection(ConnectionManager):
         self.base_url = value
 
     @property
+    def grant_type(self):
+        """Get grant type.
+
+        :returns: Grant type
+        :rtype: str
+        """
+        return self._grant_type
+
+    @grant_type.setter
+    def grant_type(self, value):
+        self._grant_type = value
+
+    @property
     def realm_name(self):
         """Get realm name.
 


### PR DESCRIPTION
When an x509 certificate is given to access the Keycloak admin interface we cannot get a new token. This PR fixes the issue