### PR TITLE
Add optional Nonce parameter to the authorization URL requests

### DIFF
--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -266,7 +266,7 @@ class KeycloakOpenID:
         :type scope: str
         :param state: State will be returned to the redirect_uri
         :type state: str
-        :param nonce: Associates a Client session with an ID Token, and used to mitigate replay attacks
+        :param nonce: Associates a Client session with an ID Token to mitigate replay attacks
         :type nonce: str
         :returns: Authorization URL Full Build
         :rtype: str
@@ -915,7 +915,7 @@ class KeycloakOpenID:
         :type scope: str
         :param state: State will be returned to the redirect_uri
         :type state: str
-        :param nonce: Associates a Client session with an ID Token, and used to mitigate replay attacks
+        :param nonce: Associates a Client session with an ID Token to mitigate replay attacks
         :type nonce: str
         :returns: Authorization URL Full Build
         :rtype: str

--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -257,7 +257,7 @@ class KeycloakOpenID:
         data_raw = self.connection.raw_get(URL_WELL_KNOWN.format(**params_path))
         return raise_error_from_response(data_raw, KeycloakGetError)
 
-    def auth_url(self, redirect_uri, scope="email", state=""):
+    def auth_url(self, redirect_uri, scope="email", state="", nonce=""):
         """Get authorization URL endpoint.
 
         :param redirect_uri: Redirect url to receive oauth code
@@ -266,6 +266,8 @@ class KeycloakOpenID:
         :type scope: str
         :param state: State will be returned to the redirect_uri
         :type state: str
+        :param nonce: Associates a Client session with an ID Token, and used to mitigate replay attacks
+        :type nonce: str
         :returns: Authorization URL Full Build
         :rtype: str
         """
@@ -275,6 +277,7 @@ class KeycloakOpenID:
             "redirect-uri": redirect_uri,
             "scope": scope,
             "state": state,
+            "nonce": nonce,
         }
         return URL_AUTH.format(**params_path)
 
@@ -903,7 +906,7 @@ class KeycloakOpenID:
         data_raw = await self.connection.a_raw_get(URL_WELL_KNOWN.format(**params_path))
         return raise_error_from_response(data_raw, KeycloakGetError)
 
-    async def a_auth_url(self, redirect_uri, scope="email", state=""):
+    async def a_auth_url(self, redirect_uri, scope="email", state="", nonce=""):
         """Get authorization URL endpoint asynchronously.
 
         :param redirect_uri: Redirect url to receive oauth code
@@ -912,6 +915,8 @@ class KeycloakOpenID:
         :type scope: str
         :param state: State will be returned to the redirect_uri
         :type state: str
+        :param nonce: Associates a Client session with an ID Token, and used to mitigate replay attacks
+        :type nonce: str
         :returns: Authorization URL Full Build
         :rtype: str
         """
@@ -921,6 +926,7 @@ class KeycloakOpenID:
             "redirect-uri": redirect_uri,
             "scope": scope,
             "state": state,
+            "nonce": nonce,
         }
         return URL_AUTH.format(**params_path)
 

--- a/src/keycloak/urls_patterns.py
+++ b/src/keycloak/urls_patterns.py
@@ -35,7 +35,7 @@ URL_INTROSPECT = "realms/{realm-name}/protocol/openid-connect/token/introspect"
 URL_ENTITLEMENT = "realms/{realm-name}/authz/entitlement/{resource-server-id}"
 URL_AUTH = (
     "{authorization-endpoint}?client_id={client-id}&response_type=code&redirect_uri={redirect-uri}"
-    "&scope={scope}&state={state}"
+    "&scope={scope}&state={state}&nonce={nonce}"
 )
 URL_DEVICE = "realms/{realm-name}/protocol/openid-connect/auth/device"
 

--- a/tests/test_keycloak_openid.py
+++ b/tests/test_keycloak_openid.py
@@ -121,7 +121,7 @@ def test_auth_url(env, oid: KeycloakOpenID):
         res
         == f"http://{env.KEYCLOAK_HOST}:{env.KEYCLOAK_PORT}/realms/{oid.realm_name}"
         + f"/protocol/openid-connect/auth?client_id={oid.client_id}&response_type=code"
-        + "&redirect_uri=http://test.test/*&scope=email&state="
+        + "&redirect_uri=http://test.test/*&scope=email&state=&nonce="
     )
 
 
@@ -575,7 +575,7 @@ async def test_a_auth_url(env, oid: KeycloakOpenID):
         res
         == f"http://{env.KEYCLOAK_HOST}:{env.KEYCLOAK_PORT}/realms/{oid.realm_name}"
         + f"/protocol/openid-connect/auth?client_id={oid.client_id}&response_type=code"
-        + "&redirect_uri=http://test.test/*&scope=email&state="
+        + "&redirect_uri=http://test.test/*&scope=email&state=&nonce="
     )
 
 


### PR DESCRIPTION
Per the [OIDC Spec](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest), the authentication request may include a [nonce parameter](https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes) that helps to mitigate ID Token replay attacks. If not provided to the `auth_url` functions it will fail safely. 