### PR TITLE
Make sure to not call sync IO functions inside async functions

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -6199,7 +6199,7 @@ class KeycloakAdmin:
         :rtype: str
         """
         if skip_exists:
-            client_id = self.get_client_id(client_id=payload["clientId"])
+            client_id = await self.a_get_client_id(client_id=payload["clientId"])
 
             if client_id is not None:
                 return client_id
@@ -6369,7 +6369,7 @@ class KeycloakAdmin:
         """
         params_path = {
             "realm-name": self.connection.realm_name,
-            "role-id": self.get_default_realm_role_id(),
+            "role-id": await self.a_get_default_realm_role_id(),
         }
         data_raw = await self.connection.a_raw_get(
             urls_patterns.URL_ADMIN_REALM_ROLE_COMPOSITES_REALM.format(**params_path)
@@ -6386,7 +6386,7 @@ class KeycloakAdmin:
         """
         params_path = {
             "realm-name": self.connection.realm_name,
-            "role-id": self.get_default_realm_role_id(),
+            "role-id": await self.a_get_default_realm_role_id(),
         }
         data_raw = await self.connection.a_raw_delete(
             urls_patterns.URL_ADMIN_REALM_ROLE_COMPOSITES.format(**params_path),
@@ -6404,7 +6404,7 @@ class KeycloakAdmin:
         """
         params_path = {
             "realm-name": self.connection.realm_name,
-            "role-id": self.get_default_realm_role_id(),
+            "role-id": await self.a_get_default_realm_role_id(),
         }
         data_raw = await self.connection.a_raw_post(
             urls_patterns.URL_ADMIN_REALM_ROLE_COMPOSITES.format(**params_path),
@@ -7536,7 +7536,7 @@ class KeycloakAdmin:
         :rtype: dict
         """
         params_path = {"realm-name": self.connection.realm_name, "provider-id": provider_id}
-        data_raw = self.connection.raw_get(
+        data_raw = await self.connection.a_raw_get(
             urls_patterns.URL_ADMIN_AUTHENTICATOR_CONFIG_DESCRIPTION.format(**params_path)
         )
         return raise_error_from_response(data_raw, KeycloakGetError)
@@ -7678,7 +7678,7 @@ class KeycloakAdmin:
         :rtype: str
         """
         if skip_exists:
-            exists = self.get_client_scope_by_name(client_scope_name=payload["name"])
+            exists = await self.a_get_client_scope_by_name(client_scope_name=payload["name"])
 
             if exists is not None:
                 return exists["id"]
@@ -8002,7 +8002,7 @@ class KeycloakAdmin:
             "realm-name": self.connection.realm_name,
             "scope-id": client_scope_id,
         }
-        data_raw = self.connection.raw_get(
+        data_raw = await self.connection.a_raw_get(
             urls_patterns.URL_ADMIN_CLIENT_SCOPE_ROLE_MAPPINGS.format(**params_path)
         )
         return raise_error_from_response(data_raw, KeycloakGetError)

--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -892,6 +892,25 @@ class KeycloakOpenID:
         )
         return raise_error_from_response(data_raw, KeycloakPutError)
 
+    async def _a_token_info(self, token, method_token_info, **kwargs):
+        """Asynchronous getter for the token data.
+
+        :param token: Token
+        :type token: str
+        :param method_token_info: Token info method to use
+        :type method_token_info: str
+        :param kwargs: Additional keyword arguments passed to the decode_token method
+        :type kwargs: dict
+        :returns: Token info
+        :rtype: dict
+        """
+        if method_token_info == "introspect":
+            token_info = await self.a_introspect(token)
+        else:
+            token_info = await self.a_decode_token(token, **kwargs)
+
+        return token_info
+
     async def a_well_known(self):
         """Get the well_known object asynchronously.
 
@@ -1301,7 +1320,7 @@ class KeycloakOpenID:
                 "Keycloak settings not found. Load Authorization Keycloak settings."
             )
 
-        token_info = self._token_info(token, method_token_info, **kwargs)
+        token_info = await self._a_token_info(token, method_token_info, **kwargs)
 
         if method_token_info == "introspect" and not token_info["active"]:
             raise KeycloakInvalidTokenError("Token expired or invalid.")
@@ -1339,7 +1358,7 @@ class KeycloakOpenID:
                 "Keycloak settings not found. Load Authorization Keycloak settings."
             )
 
-        token_info = self._token_info(token, method_token_info, **kwargs)
+        token_info = await self._a_token_info(token, method_token_info, **kwargs)
 
         if method_token_info == "introspect" and not token_info["active"]:
             raise KeycloakInvalidTokenError("Token expired or invalid.")

--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -1397,7 +1397,7 @@ class KeycloakOpenID:
         params_path = {"realm-name": self.realm_name}
         payload = {
             "grant_type": "urn:ietf:params:oauth:grant-type:uma-ticket",
-            "permission": permission,
+            "permission": list(permission), # httpx does not handle sets correctly
             "response_mode": "permissions",
             "audience": self.client_id,
         }

--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -1397,7 +1397,7 @@ class KeycloakOpenID:
         params_path = {"realm-name": self.realm_name}
         payload = {
             "grant_type": "urn:ietf:params:oauth:grant-type:uma-ticket",
-            "permission": list(permission), # httpx does not handle `set` correctly
+            "permission": list(permission),  # httpx does not handle `set` correctly
             "response_mode": "permissions",
             "audience": self.client_id,
         }

--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -1397,7 +1397,7 @@ class KeycloakOpenID:
         params_path = {"realm-name": self.realm_name}
         payload = {
             "grant_type": "urn:ietf:params:oauth:grant-type:uma-ticket",
-            "permission": list(permission), # httpx does not handle sets correctly
+            "permission": list(permission), # httpx does not handle `set` correctly
             "response_mode": "permissions",
             "audience": self.client_id,
         }

--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -1406,7 +1406,7 @@ class KeycloakOpenID:
         self.connection.add_param_headers("Authorization", "Bearer " + token)
         content_type = self.connection.headers.get("Content-Type")
         self.connection.add_param_headers("Content-Type", "application/x-www-form-urlencoded")
-        data_raw = self.connection.raw_post(URL_TOKEN.format(**params_path), data=payload)
+        data_raw = await self.connection.a_raw_post(URL_TOKEN.format(**params_path), data=payload)
         (
             self.connection.add_param_headers("Content-Type", content_type)
             if content_type

--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -674,7 +674,7 @@ class KeycloakOpenID:
         return list(set(policies))
 
     def get_permissions(self, token, method_token_info="introspect", **kwargs):
-        """Get permission by user token .
+        """Get permission by user token.
 
         :param token: user token
         :type token: str
@@ -689,7 +689,7 @@ class KeycloakOpenID:
         """
         if not self.authorization.policies:
             raise KeycloakAuthorizationConfigError(
-                "Keycloak settings not found. Load Authorization Keycloak settings ."
+                "Keycloak settings not found. Load Authorization Keycloak settings."
             )
 
         token_info = self._token_info(token, method_token_info, **kwargs)


### PR DESCRIPTION
I found that several sync IO functions are used inside of `async` functions. This is not good, as sync IO may block the eventloop for undetermined amount of time.
I had to add a new `_a_token_info` that mimics `_token_info`; the only difference is that it calls the async alternatives inside.
I think those should be all the places where a sync IO was made.

I also found another discrepancy between `requests` and `httpx` - `httpx` does not handle `set`s for form-data requests.
Encoding in [requests](https://github.com/psf/requests/blob/23540c93cac97c763fe59e843a08fa2825aa80fd/src/requests/models.py#L119) vs [httpx](https://github.com/encode/httpx/blob/1805ee0d22f96e2b29f0500dd3076e10020004bf/httpx/_content.py#L141). httpx doesn't mention anything about support or lack of it for sets. Perhaps it could be reasonable for it to be fixed upstream.
Luckily some tests for `a_uma_permissions` caught this.

For now I fixed the problem inside the function itself.
The only other place I see where this could need a similar fix is `KeycloakOpenID.a_token`, which takes a user-supplied dict (the `extra`) and passes it as is to `httpx`.