### PR TITLE
feat: Feature parity for `a_decode_token` and `decode_token`

### DIFF
--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -582,12 +582,9 @@ class KeycloakOpenID:
         return raise_error_from_response(data_raw, KeycloakPostError)
 
     @staticmethod
-    def _verify_token(token, key: Union[str, jwk.JWK, jwk.JWKSet, None], **kwargs):
+    def _verify_token(token, key: Union[jwk.JWK, jwk.JWKSet, None], **kwargs):
         # keep the function free of IO
         # this way it can be used by `decode_token` and `a_decode_token`
-        if isinstance(key, str):
-            key = "-----BEGIN PUBLIC KEY-----\n" + key + "\n-----END PUBLIC KEY-----"
-            key = jwk.JWK.from_pem(key.encode("utf-8"))
 
         if key is not None:
             leeway = kwargs.pop("leeway", 60)
@@ -625,7 +622,12 @@ class KeycloakOpenID:
         key = kwargs.pop("key", None)
         if validate:
             if key is None:
-                key = self.public_key()
+                key = (
+                    "-----BEGIN PUBLIC KEY-----\n"
+                    + self.public_key()
+                    + "\n-----END PUBLIC KEY-----"
+                )
+                key = jwk.JWK.from_pem(key.encode("utf-8"))
         else:
             key = None
 
@@ -1264,7 +1266,12 @@ class KeycloakOpenID:
         key = kwargs.pop("key", None)
         if validate:
             if key is None:
-                key = await self.a_public_key()
+                key = (
+                    "-----BEGIN PUBLIC KEY-----\n"
+                    + await self.a_public_key()
+                    + "\n-----END PUBLIC KEY-----"
+                )
+                key = jwk.JWK.from_pem(key.encode("utf-8"))
         else:
             key = None
 

--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -623,8 +623,11 @@ class KeycloakOpenID:
         :rtype: dict
         """
         key = kwargs.pop("key", None)
-        if validate and key is None:
-            key = self.public_key()
+        if validate:
+            if key is None:
+                key = self.public_key()
+        else:
+            key = None
 
         return self._verify_token(token, key, **kwargs)
 
@@ -1259,8 +1262,11 @@ class KeycloakOpenID:
         :rtype: dict
         """
         key = kwargs.pop("key", None)
-        if validate and key is None:
-            key = await self.a_public_key()
+        if validate:
+            if key is None:
+                key = await self.a_public_key()
+        else:
+            key = None
 
         return self._verify_token(token, key, **kwargs)
 

--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -581,7 +581,8 @@ class KeycloakOpenID:
             )
         return raise_error_from_response(data_raw, KeycloakPostError)
 
-    def _verify_token(self, token, key, **kwargs):
+    @staticmethod
+    def _verify_token(token, key, **kwargs):
         # keep the function free of IO
         # this way it can be used by `decode_token` and `a_decode_token`
         if key is not None:

--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -586,9 +586,12 @@ class KeycloakOpenID:
         """Decode and optionally validate a token.
 
         :param token: The token to verify
+        :type token: str
         :param key: Which key should be used for validation.
             If not provided, the validation is not performed and the token is implicitly valid.
+        :type key: Union[jwk.JWK, jwk.JWKSet, None]
         :param kwargs: Additional keyword arguments for jwcrypto's JWT object
+        :type kwargs: dict
         :returns: Decoded token
         """
         # keep the function free of IO

--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -583,6 +583,14 @@ class KeycloakOpenID:
 
     @staticmethod
     def _verify_token(token, key: Union[jwk.JWK, jwk.JWKSet, None], **kwargs):
+        """Decode and optionally validate a token.
+
+        :param token: The token to verify
+        :param key: Which key should be used for validation.
+            If not provided, the validation is not performed and the token is implicitly valid.
+        :param kwargs: Additional keyword arguments for jwcrypto's JWT object
+        :returns: Decoded token
+        """
         # keep the function free of IO
         # this way it can be used by `decode_token` and `a_decode_token`
 

--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -596,6 +596,11 @@ class KeycloakOpenID:
             full_jwt.token.objects["valid"] = True
             return json.loads(full_jwt.token.payload.decode("utf-8"))
 
+    @staticmethod
+    def _public_key_to_jwk(key: str) -> jwk.JWK:
+        key = "-----BEGIN PUBLIC KEY-----\n" + key + "\n-----END PUBLIC KEY-----"
+        return jwk.JWK.from_pem(key.encode("utf-8"))
+
     def decode_token(self, token, validate: bool = True, **kwargs):
         """Decode user token.
 
@@ -620,8 +625,7 @@ class KeycloakOpenID:
         """
         key = kwargs.pop("key", None)
         if validate and key is None:
-            key = "-----BEGIN PUBLIC KEY-----\n" + self.public_key() + "\n-----END PUBLIC KEY-----"
-            key = jwk.JWK.from_pem(key.encode("utf-8"))
+            key = self._public_key_to_jwk(self.public_key())
 
         return self._verify_token(token, key, **kwargs)
 
@@ -1257,12 +1261,7 @@ class KeycloakOpenID:
         """
         key = kwargs.pop("key", None)
         if validate and key is None:
-            key = (
-                "-----BEGIN PUBLIC KEY-----\n"
-                + await self.a_public_key()
-                + "\n-----END PUBLIC KEY-----"
-            )
-            key = jwk.JWK.from_pem(key.encode("utf-8"))
+            key = self._public_key_to_jwk(await self.a_public_key())
 
         return self._verify_token(token, key, **kwargs)
 

--- a/tests/test_keycloak_openid.py
+++ b/tests/test_keycloak_openid.py
@@ -4,6 +4,8 @@ from inspect import iscoroutinefunction, signature
 from typing import Tuple
 from unittest import mock
 
+import jwcrypto.jwk
+import jwcrypto.jws
 import pytest
 
 from keycloak import KeycloakAdmin, KeycloakOpenID
@@ -315,6 +317,39 @@ def test_decode_token(oid_with_credentials: Tuple[KeycloakOpenID, str, str]):
     assert decoded_access_token == decoded_access_token_2
     assert decoded_access_token["preferred_username"] == username, decoded_access_token
     assert decoded_refresh_token["typ"] == "Refresh", decoded_refresh_token
+
+
+def test_decode_token_validate(oid_with_credentials: Tuple[KeycloakOpenID, str, str]):
+    """Test decode token.
+
+    :param oid_with_credentials: Keycloak OpenID client with pre-configured user credentials
+    :type oid_with_credentials: Tuple[KeycloakOpenID, str, str]
+    """
+    oid, username, password = oid_with_credentials
+    token = oid.token(username=username, password=password)
+    access_token = token["access_token"]
+    decoded_access_token = oid.decode_token(token=access_token)
+
+    key = oid.public_key()
+    key = "-----BEGIN PUBLIC KEY-----\n" + key + "\n-----END PUBLIC KEY-----"
+    key = jwcrypto.jwk.JWK.from_pem(key.encode("utf-8"))
+
+    invalid_access_token = access_token + "a"
+    with pytest.raises(jwcrypto.jws.InvalidJWSSignature):
+        decoded_invalid_access_token = oid.decode_token(token=invalid_access_token, validate=True)
+
+    with pytest.raises(jwcrypto.jws.InvalidJWSSignature):
+        decoded_invalid_access_token = oid.decode_token(
+            token=invalid_access_token, validate=True, key=key
+        )
+
+    decoded_invalid_access_token = oid.decode_token(token=invalid_access_token, validate=False)
+    assert decoded_access_token == decoded_invalid_access_token
+
+    decoded_invalid_access_token = oid.decode_token(
+        token=invalid_access_token, validate=False, key=key
+    )
+    assert decoded_access_token == decoded_invalid_access_token
 
 
 def test_load_authorization_config(oid_with_credentials_authz: Tuple[KeycloakOpenID, str, str]):
@@ -765,7 +800,7 @@ async def test_a_introspect(oid_with_credentials: Tuple[KeycloakOpenID, str, str
 
 @pytest.mark.asyncio
 async def test_a_decode_token(oid_with_credentials: Tuple[KeycloakOpenID, str, str]):
-    """Test decode token.
+    """Test decode token asynchronously.
 
     :param oid_with_credentials: Keycloak OpenID client with pre-configured user credentials
     :type oid_with_credentials: Tuple[KeycloakOpenID, str, str]
@@ -779,6 +814,44 @@ async def test_a_decode_token(oid_with_credentials: Tuple[KeycloakOpenID, str, s
     assert decoded_access_token == decoded_access_token_2
     assert decoded_access_token["preferred_username"] == username, decoded_access_token
     assert decoded_refresh_token["typ"] == "Refresh", decoded_refresh_token
+
+
+@pytest.mark.asyncio
+async def test_a_decode_token_validate(oid_with_credentials: Tuple[KeycloakOpenID, str, str]):
+    """Test decode token asynchronously.
+
+    :param oid_with_credentials: Keycloak OpenID client with pre-configured user credentials
+    :type oid_with_credentials: Tuple[KeycloakOpenID, str, str]
+    """
+    oid, username, password = oid_with_credentials
+    token = await oid.a_token(username=username, password=password)
+    access_token = token["access_token"]
+    decoded_access_token = await oid.a_decode_token(token=access_token)
+
+    key = await oid.a_public_key()
+    key = "-----BEGIN PUBLIC KEY-----\n" + key + "\n-----END PUBLIC KEY-----"
+    key = jwcrypto.jwk.JWK.from_pem(key.encode("utf-8"))
+
+    invalid_access_token = access_token + "a"
+    with pytest.raises(jwcrypto.jws.InvalidJWSSignature):
+        decoded_invalid_access_token = await oid.a_decode_token(
+            token=invalid_access_token, validate=True
+        )
+
+    with pytest.raises(jwcrypto.jws.InvalidJWSSignature):
+        decoded_invalid_access_token = await oid.a_decode_token(
+            token=invalid_access_token, validate=True, key=key
+        )
+
+    decoded_invalid_access_token = await oid.a_decode_token(
+        token=invalid_access_token, validate=False
+    )
+    assert decoded_access_token == decoded_invalid_access_token
+
+    decoded_invalid_access_token = await oid.a_decode_token(
+        token=invalid_access_token, validate=False, key=key
+    )
+    assert decoded_access_token == decoded_invalid_access_token
 
 
 @pytest.mark.asyncio

--- a/tests/test_keycloak_openid.py
+++ b/tests/test_keycloak_openid.py
@@ -319,8 +319,8 @@ def test_decode_token(oid_with_credentials: Tuple[KeycloakOpenID, str, str]):
     assert decoded_refresh_token["typ"] == "Refresh", decoded_refresh_token
 
 
-def test_decode_token_validate(oid_with_credentials: Tuple[KeycloakOpenID, str, str]):
-    """Test decode token.
+def test_decode_token_invalid_token(oid_with_credentials: Tuple[KeycloakOpenID, str, str]):
+    """Test decode token with an invalid token.
 
     :param oid_with_credentials: Keycloak OpenID client with pre-configured user credentials
     :type oid_with_credentials: Tuple[KeycloakOpenID, str, str]
@@ -817,8 +817,8 @@ async def test_a_decode_token(oid_with_credentials: Tuple[KeycloakOpenID, str, s
 
 
 @pytest.mark.asyncio
-async def test_a_decode_token_validate(oid_with_credentials: Tuple[KeycloakOpenID, str, str]):
-    """Test decode token asynchronously.
+async def test_a_decode_token_invalid_token(oid_with_credentials: Tuple[KeycloakOpenID, str, str]):
+    """Test decode token asynchronously an invalid token.
 
     :param oid_with_credentials: Keycloak OpenID client with pre-configured user credentials
     :type oid_with_credentials: Tuple[KeycloakOpenID, str, str]


### PR DESCRIPTION
I saw that the `decode_token` allows configuring the `leeway` (introduced as part of #568), but the same feature is unavailable in `a_decode_token`.
In an attempt to bridge the gap between, I refactored out the logic to validate the token, leaving the functions only responsible for fetching the public key.
Also fix the case with using `validate=False` + a `key` resulting in the validation still being executed.

There is a slight difference in the behaviour though, with regards to how `key=None` is handled:
Before:
A call like `decode_token(token, validate=True, key=None)` would be considered "okay", but fail with `jwcrypto.jws.InvalidJWSSignature: Verification failed for all signatures["Failed: [ValueError('Unrecognized key type')]"]` because the key was `None`.
With the new change:
The same call will fetch the public key and use it to validate the token.

I think it's an acceptable change in behaviour/API, as I doubt an exception was what consumers would want.
