### PR TITLE
fix: change httpx proxies argument to mounts

### DIFF
--- a/src/keycloak/connection.py
+++ b/src/keycloak/connection.py
@@ -102,7 +102,7 @@ class ConnectionManager(object):
         if proxies:
             self._s.proxies.update(proxies)
 
-        self.async_s = httpx.AsyncClient(verify=verify, proxies=proxies, cert=cert)
+        self.async_s = httpx.AsyncClient(verify=verify, mounts=proxies, cert=cert)
         self.async_s.auth = None  # don't let requests add auth headers
         self.async_s.transport = httpx.AsyncHTTPTransport(retries=1)
 


### PR DESCRIPTION
Due to recent httpx library changes, `proxies` has been replaced for `proxy` and `mounts`.

Changelog for httpx: https://github.com/encode/httpx/blob/master/CHANGELOG.md#0280-28th-november-2024

Docs:
- https://www.python-httpx.org/advanced/proxies/
- https://www.python-httpx.org/api/#asyncclient

