### PR TITLE
Add py.typed marker file (pep-561)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 packages = [
     { include = "keycloak", from = "src/" },
     { include = "keycloak/**/*.py", from = "src/" },
+    { include = "keycloak/py.typed", from = "src/" },
 ]
 include = ["LICENSE", "CHANGELOG.md", "CONTRIBUTING.md"]
 


### PR DESCRIPTION
Hi,

This change allows to use Mypy to type-check a project using python-keycloak without requiring further configuration and without raising an error
> Skipping analyzing "keycloak": module is installed, but missing library stubs or py.typed marker  [import-untyped]

Btw: thanks for your work ;)