### PR TITLE
feat: adds support for group get all roles endpoint

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -4007,8 +4007,7 @@ class KeycloakAdmin:
         params_path = {"realm-name": self.connection.realm_name, "id": group_id}
         params = {"briefRepresentation": brief_representation}
         data_raw = self.connection.raw_get(
-            urls_patterns.URL_ADMIN_GROUP_ALL_ROLES.format(**params_path),
-            **params
+            urls_patterns.URL_ADMIN_GROUP_ALL_ROLES.format(**params_path), **params
         )
         return raise_error_from_response(data_raw, KeycloakGetError)
 
@@ -9298,9 +9297,7 @@ class KeycloakAdmin:
         return raise_error_from_response(data_raw, KeycloakGetError)
 
     async def a_get_all_roles_of_group(
-            self,
-            group_id: str,
-            brief_representation: bool = True
+        self, group_id: str, brief_representation: bool = True
     ) -> dict:
         """
         Get all roles of a group asynchronously.
@@ -9315,8 +9312,7 @@ class KeycloakAdmin:
         params_path = {"realm-name": self.connection.realm_name, "id": group_id}
         params = {"briefRepresentation": brief_representation}
         data_raw = await self.connection.a_raw_get(
-            urls_patterns.URL_ADMIN_GROUP_ALL_ROLES.format(**params_path),
-            **params
+            urls_patterns.URL_ADMIN_GROUP_ALL_ROLES.format(**params_path), **params
         )
         return raise_error_from_response(data_raw, KeycloakGetError)
 

--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -9297,7 +9297,11 @@ class KeycloakAdmin:
         )
         return raise_error_from_response(data_raw, KeycloakGetError)
 
-    async def a_get_all_roles_of_group(self, group_id: str, brief_representation: bool = True) -> dict:
+    async def a_get_all_roles_of_group(
+            self,
+            group_id: str,
+            brief_representation: bool = True
+    ) -> dict:
         """
         Get all roles of a group asynchronously.
 

--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -3993,6 +3993,25 @@ class KeycloakAdmin:
         )
         return raise_error_from_response(data_raw, KeycloakGetError)
 
+    def get_all_roles_of_group(self, group_id: str, brief_representation: bool = True) -> dict:
+        """
+        Get all roles of a group.
+
+        :param group_id: id of the group
+        :type group_id: str
+        :param brief_representation: whether to omit role attributes in the response
+        :type brief_representation: bool
+        :return: Keycloak server response
+        :rtype: list
+        """
+        params_path = {"realm-name": self.connection.realm_name, "id": group_id}
+        params = {"briefRepresentation": brief_representation}
+        data_raw = self.connection.raw_get(
+            urls_patterns.URL_ADMIN_GROUP_ALL_ROLES.format(**params_path),
+            **params
+        )
+        return raise_error_from_response(data_raw, KeycloakGetError)
+
     def delete_group_client_roles(self, group_id: str, client_id: str, roles: str | list) -> bytes:
         """
         Delete client roles of a group.
@@ -9275,6 +9294,25 @@ class KeycloakAdmin:
         }
         data_raw = await self.connection.a_raw_get(
             urls_patterns.URL_ADMIN_GROUPS_CLIENT_ROLES.format(**params_path),
+        )
+        return raise_error_from_response(data_raw, KeycloakGetError)
+
+    async def a_get_all_roles_of_group(self, group_id: str, brief_representation: bool = True) -> dict:
+        """
+        Get all roles of a group asynchronously.
+
+        :param group_id: id of the group
+        :type group_id: str
+        :param brief_representation: whether to omit role attributes in the response
+        :type brief_representation: bool
+        :return: Keycloak server response
+        :rtype: list
+        """
+        params_path = {"realm-name": self.connection.realm_name, "id": group_id}
+        params = {"briefRepresentation": brief_representation}
+        data_raw = await self.connection.a_raw_get(
+            urls_patterns.URL_ADMIN_GROUP_ALL_ROLES.format(**params_path),
+            **params
         )
         return raise_error_from_response(data_raw, KeycloakGetError)
 

--- a/src/keycloak/urls_patterns.py
+++ b/src/keycloak/urls_patterns.py
@@ -62,9 +62,7 @@ URL_ADMIN_USER_REALM_ROLES_AVAILABLE = (
 URL_ADMIN_USER_REALM_ROLES_COMPOSITE = (
     "admin/realms/{realm-name}/users/{id}/role-mappings/realm/composite"
 )
-URL_ADMIN_GROUP_ALL_ROLES = (
-    "admin/realms/{realm-name}/groups/{id}/role-mappings"
-)
+URL_ADMIN_GROUP_ALL_ROLES = "admin/realms/{realm-name}/groups/{id}/role-mappings"
 URL_ADMIN_GROUPS_REALM_ROLES = "admin/realms/{realm-name}/groups/{id}/role-mappings/realm"
 URL_ADMIN_GROUPS_CLIENT_ROLES = (
     "admin/realms/{realm-name}/groups/{id}/role-mappings/clients/{client-id}"

--- a/src/keycloak/urls_patterns.py
+++ b/src/keycloak/urls_patterns.py
@@ -62,6 +62,9 @@ URL_ADMIN_USER_REALM_ROLES_AVAILABLE = (
 URL_ADMIN_USER_REALM_ROLES_COMPOSITE = (
     "admin/realms/{realm-name}/users/{id}/role-mappings/realm/composite"
 )
+URL_ADMIN_GROUP_ALL_ROLES = (
+    "admin/realms/{realm-name}/groups/{id}/role-mappings"
+)
 URL_ADMIN_GROUPS_REALM_ROLES = "admin/realms/{realm-name}/groups/{id}/role-mappings/realm"
 URL_ADMIN_GROUPS_CLIENT_ROLES = (
     "admin/realms/{realm-name}/groups/{id}/role-mappings/clients/{client-id}"


### PR DESCRIPTION
I have no tests right now, but this PR give you ability to request all bindings (clients and realm) for a group with one request, just like keycloak do it in the admin panel.
