### PR TITLE
fix: correct return type hint in get_all_roles_of_user and a_get_all_roles_of_user

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -4049,14 +4049,14 @@ class KeycloakAdmin:
             expected_codes=[HTTP_NO_CONTENT],
         )
 
-    def get_all_roles_of_user(self, user_id: str) -> list:
+    def get_all_roles_of_user(self, user_id: str) -> dict:
         """
         Get all level roles for a user.
 
         :param user_id: id of user
         :type user_id: str
-        :return: Keycloak server response (array RoleRepresentation)
-        :rtype: list
+        :return: Keycloak server response (MappingsRepresentation)
+        :rtype: dict
         """
         params_path = {"realm-name": self.connection.realm_name, "id": user_id}
         data_raw = self.connection.raw_get(
@@ -9361,14 +9361,14 @@ class KeycloakAdmin:
             expected_codes=[HTTP_NO_CONTENT],
         )
 
-    async def a_get_all_roles_of_user(self, user_id: str) -> list:
+    async def a_get_all_roles_of_user(self, user_id: str) -> dict:
         """
         Get all level roles for a user asynchronously.
 
         :param user_id: id of user
         :type user_id: str
-        :return: Keycloak server response (array RoleRepresentation)
-        :rtype: list
+        :return: Keycloak server response (MappingsRepresentation)
+        :rtype: dict
         """
         params_path = {"realm-name": self.connection.realm_name, "id": user_id}
         data_raw = await self.connection.a_raw_get(


### PR DESCRIPTION
Previously, both methods (get_all_roles_of_user and a_get_all_roles_of_user) were annotated to return a list, but they actually return a dict corresponding to the [MappingsRepresentation](https://www.keycloak.org/docs-api/latest/rest-api/index.html#MappingsRepresentation) model from the Keycloak API.

API method documentation: [Get role mappings for a user](https://www.keycloak.org/docs-api/latest/rest-api/index.html#_get_adminrealmsrealmusersuser_idrole_mappings)

Current tests also work with output as dict. Example `tests/test_keycloak_admin.py:4131`:
```python
@pytest.mark.asyncio
async def test_a_users_roles(admin: KeycloakAdmin, realm: str) -> None:
    ...
    all_roles = await admin.a_get_all_roles_of_user(user_id=user_id)
    realm_roles = all_roles["realmMappings"]
    assert len(realm_roles) == 1, realm_roles
    ...
```