### PR TITLE
Prevent all HTTPX deprecation warnings

### DIFF
--- a/tests/test_keycloak_admin.py
+++ b/tests/test_keycloak_admin.py
@@ -6156,7 +6156,7 @@ async def test_a_email_query_param_handling(admin: KeycloakAdmin, user: str) -> 
 
     mock_put.assert_awaited_once_with(
         ANY,
-        data='["UPDATE_PASSWORD"]',
+        content='["UPDATE_PASSWORD"]',
         params={"client_id": "update-account-client-id", "redirect_uri": "https://example.com"},
         headers=ANY,
         timeout=60,


### PR DESCRIPTION
As noted in #646, people are seeing HTTPX deprecation warnings due to [this](https://www.python-httpx.org/compatibility/#request-content). In testing, this is causing hundreds of warnings. 

I isolated these warnings to the async functions, which is the only place where HTTPX is being used. Although a bit ugly, a small helper function to use the correct kwarg to `httpx.AsyncClient.request` resolved these warnings. 

Closes #646