### PR TITLE
chore: correct return type hint in uma_permissions and a_uma_permissions

### DIFF
--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -790,7 +790,7 @@ class KeycloakOpenID:
 
         return list(set(permissions))
 
-    def uma_permissions(self, token: str, permissions: str = "", **extra_payload: dict) -> dict:
+    def uma_permissions(self, token: str, permissions: str = "", **extra_payload: dict) -> list:
         """
         Get UMA permissions by user token with requested permissions.
 
@@ -806,7 +806,7 @@ class KeycloakOpenID:
         :param extra_payload: Additional payload data
         :type extra_payload: dict
         :returns: Keycloak server response
-        :rtype: dict
+        :rtype: list
         """
         permission = build_permission_param(permissions)
 
@@ -1516,7 +1516,7 @@ class KeycloakOpenID:
         token: str,
         permissions: str = "",
         **extra_payload: dict,
-    ) -> dict:
+    ) -> list:
         """
         Get UMA permissions by user token with requested permissions asynchronously.
 
@@ -1532,7 +1532,7 @@ class KeycloakOpenID:
         :param extra_payload: Additional payload data
         :type extra_payload: dict
         :returns: Keycloak server response
-        :rtype: dict
+        :rtype: list
         """
         permission = build_permission_param(permissions)
 


### PR DESCRIPTION
## Fix uma_permissions return type hint

The `uma_permissions` method is annotated to return `dict` but actually returns `list`. This causes mypy warnings when handling the response as a list.

**Changes:**
- Update return type hint from `dict` to `list` for both sync and async methods
- Update docstring `:rtype:` annotations accordingly

**Note:**
I noticed @Ujifman reported this issue but hasn't received feedback yet. If this approach is not appropriate, please feel free to decline and provide guidance.

Fixes #663