### PR TITLE
chore: correct argument type hint in send_update_account and a_send_u…

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -1671,7 +1671,7 @@ class KeycloakAdmin:
     def send_update_account(
         self,
         user_id: str,
-        payload: dict,
+        payload: list,
         client_id: str | None = None,
         lifespan: int | None = None,
         redirect_uri: str | None = None,
@@ -6955,7 +6955,7 @@ class KeycloakAdmin:
     async def a_send_update_account(
         self,
         user_id: str,
-        payload: dict,
+        payload: list,
         client_id: str | None = None,
         lifespan: int | None = None,
         redirect_uri: str | None = None,


### PR DESCRIPTION
The payload argument of send_update_account is defined as a dict. but it should actually be a list
(i did not change docstring because it was defined as a list)

### Docs:
* [PUT /admin/realms/{realm}/users/{user-id}/execute-actions-email](https://www.keycloak.org/docs-api/latest/rest-api/index.html#_put_adminrealmsrealmusersuser_idexecute_actions_email)

### Changes:
* Update argument type hint from dict to list in send_update_account