### PR TITLE
fix: update payload for send update account to match API signature (#684)

### DIFF
--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -1671,7 +1671,7 @@ class KeycloakAdmin:
     def send_update_account(
         self,
         user_id: str,
-        payload: dict,
+        payload: list,
         client_id: str | None = None,
         lifespan: int | None = None,
         redirect_uri: str | None = None,
@@ -6955,7 +6955,7 @@ class KeycloakAdmin:
     async def a_send_update_account(
         self,
         user_id: str,
-        payload: dict,
+        payload: list,
         client_id: str | None = None,
         lifespan: int | None = None,
         redirect_uri: str | None = None,


### PR DESCRIPTION
This API takes a list of strings as an input instead of a dict.

```
PUT /admin/realms/{realm}/users/{user-id}/execute-actions-email
Send an email to the user with a link they can click to execute particular actions.

Body Parameter
string optional [string]
```

as per the docs

Correct call is like this in my code:

```python
        KEYCLOAK_ADMIN.send_update_account(  # type: ignore[reportUnknownReturnType]
            user_id=str(keycloak_id_user),
            payload=["VERIFY_EMAIL", "UPDATE_PASSWORD"],
            client_id=KEYCLOAK_CLIENT_ID,
            redirect_uri=redirect_uri,
        )
```

closes #684 