### PR TITLE
feat(admin): add user_logout_session to log out a single user session

### DIFF
--- a/docs/source/modules/admin.rst
+++ b/docs/source/modules/admin.rst
@@ -196,3 +196,10 @@ Get sessions associated with the user
 .. code-block:: python
 
     sessions = keycloak_admin.get_sessions(user_id="user-id-keycloak")
+
+Log out a single session of the user
+--------------------------------------
+
+.. code-block:: python
+
+    keycloak_admin.user_logout_session(user_id="user-id-keycloak", session_id="session-id")

--- a/src/keycloak/keycloak_admin.py
+++ b/src/keycloak/keycloak_admin.py
@@ -1898,6 +1898,56 @@ class KeycloakAdmin:
 
         return res
 
+    def user_logout_session(
+        self,
+        user_id: str,
+        session_id: str,
+        is_offline: bool = False,
+    ) -> dict:
+        """
+        Log out a single session of the user.
+
+        Unlike :func:`user_logout`, which terminates all of the user's sessions, this
+        removes only the session identified by ``session_id``.
+
+        https://www.keycloak.org/docs-api/24.0.2/rest-api/index.html#_delete_adminrealmsrealmsessionssession
+
+        :param user_id: User id
+        :type user_id: str
+        :param session_id: Id of the session to log out
+        :type session_id: str
+        :param is_offline: Whether the session to remove is an offline session
+        :type is_offline: bool
+        :returns: Keycloak server response
+        :rtype: dict
+        :raises KeycloakDeleteError: When the session does not belong to the user
+        """
+        if not is_offline:
+            sessions = self.get_sessions(user_id=user_id)
+            if session_id not in {session.get("id") for session in sessions}:
+                msg = f"User '{user_id}' has no session with id '{session_id}'."
+                raise KeycloakDeleteError(msg)
+
+        params_path = {"realm-name": self.connection.realm_name, "session-id": session_id}
+        params_query = {"isOffline": is_offline}
+        data_raw = self.connection.raw_delete(
+            urls_patterns.URL_ADMIN_USER_LOGOUT_SESSION.format(**params_path),
+            **params_query,
+        )
+        res = raise_error_from_response(
+            data_raw,
+            KeycloakDeleteError,
+            expected_codes=[HTTP_NO_CONTENT],
+        )
+        if not isinstance(res, dict):
+            msg = (
+                "Unexpected response type. Expected 'dict', received "
+                f"'{type(res)}', value '{res}'."
+            )
+            raise TypeError(msg)
+
+        return res
+
     def user_consents(self, user_id: str) -> list:
         """
         Get consents granted by the user.
@@ -8782,6 +8832,56 @@ class KeycloakAdmin:
         res = raise_error_from_response(
             data_raw,
             KeycloakPostError,
+            expected_codes=[HTTP_NO_CONTENT],
+        )
+        if not isinstance(res, dict):
+            msg = (
+                "Unexpected response type. Expected 'dict', received "
+                f"'{type(res)}', value '{res}'."
+            )
+            raise TypeError(msg)
+
+        return res
+
+    async def a_user_logout_session(
+        self,
+        user_id: str,
+        session_id: str,
+        is_offline: bool = False,
+    ) -> dict:
+        """
+        Log out a single session of the user.
+
+        Unlike :func:`a_user_logout`, which terminates all of the user's sessions, this
+        removes only the session identified by ``session_id``.
+
+        https://www.keycloak.org/docs-api/24.0.2/rest-api/index.html#_delete_adminrealmsrealmsessionssession
+
+        :param user_id: User id
+        :type user_id: str
+        :param session_id: Id of the session to log out
+        :type session_id: str
+        :param is_offline: Whether the session to remove is an offline session
+        :type is_offline: bool
+        :returns: Keycloak server response
+        :rtype: dict
+        :raises KeycloakDeleteError: When the session does not belong to the user
+        """
+        if not is_offline:
+            sessions = await self.a_get_sessions(user_id=user_id)
+            if session_id not in {session.get("id") for session in sessions}:
+                msg = f"User '{user_id}' has no session with id '{session_id}'."
+                raise KeycloakDeleteError(msg)
+
+        params_path = {"realm-name": self.connection.realm_name, "session-id": session_id}
+        params_query = {"isOffline": is_offline}
+        data_raw = await self.connection.a_raw_delete(
+            urls_patterns.URL_ADMIN_USER_LOGOUT_SESSION.format(**params_path),
+            **params_query,
+        )
+        res = raise_error_from_response(
+            data_raw,
+            KeycloakDeleteError,
             expected_codes=[HTTP_NO_CONTENT],
         )
         if not isinstance(res, dict):

--- a/src/keycloak/urls_patterns.py
+++ b/src/keycloak/urls_patterns.py
@@ -77,6 +77,7 @@ URL_ADMIN_USER_GROUPS = "admin/realms/{realm-name}/users/{id}/groups"
 URL_ADMIN_USER_CREDENTIALS = "admin/realms/{realm-name}/users/{id}/credentials"
 URL_ADMIN_USER_CREDENTIAL = "admin/realms/{realm-name}/users/{id}/credentials/{credential_id}"
 URL_ADMIN_USER_LOGOUT = "admin/realms/{realm-name}/users/{id}/logout"
+URL_ADMIN_USER_LOGOUT_SESSION = "admin/realms/{realm-name}/sessions/{session-id}"
 URL_ADMIN_USER_STORAGE = "admin/realms/{realm-name}/user-storage/{id}/sync"
 
 URL_ADMIN_SERVER_INFO = "admin/serverinfo"

--- a/tests/test_keycloak_admin.py
+++ b/tests/test_keycloak_admin.py
@@ -2586,6 +2586,46 @@ def test_get_sessions(admin: KeycloakAdmin) -> None:
     assert err.match(USER_NOT_FOUND_REGEX)
 
 
+def test_user_logout_session(
+    admin: KeycloakAdmin, oid_with_credentials: tuple[KeycloakOpenID, str, str]
+) -> None:
+    """
+    Test logging out a single user session.
+
+    :param admin: Keycloak Admin client
+    :type admin: KeycloakAdmin
+    :param oid_with_credentials: Keycloak OpenID client with pre-configured user credentials
+    :type oid_with_credentials: Tuple[KeycloakOpenID, str, str]
+    """
+    oid, username, password = oid_with_credentials
+
+    # Create a session by logging the user in
+    token = oid.token(username, password)
+    user_id = oid.decode_token(token=token["access_token"])["sub"]
+
+    sessions = admin.get_sessions(user_id=user_id)
+    assert len(sessions) >= 1
+    session_id = sessions[0]["id"]
+
+    # Logging out a session that does not belong to the user is rejected locally
+    with pytest.raises(KeycloakDeleteError):
+        admin.user_logout_session(user_id=user_id, session_id="non-existent-session")
+
+    # Skipping the validation (is_offline) lets the server reject an unknown session
+    with pytest.raises(KeycloakDeleteError):
+        admin.user_logout_session(
+            user_id=user_id, session_id="non-existent-session", is_offline=True
+        )
+
+    # Log out only the specific session
+    res = admin.user_logout_session(user_id=user_id, session_id=session_id)
+    assert res == {}
+
+    # The targeted session is gone
+    sessions = admin.get_sessions(user_id=user_id)
+    assert session_id not in {session["id"] for session in sessions}
+
+
 def test_get_client_installation_provider(admin: KeycloakAdmin, client: str) -> None:
     """
     Test get client installation provider.
@@ -6421,6 +6461,47 @@ async def test_a_get_sessions(admin: KeycloakAdmin) -> None:
     with pytest.raises(KeycloakGetError) as err:
         await admin.a_get_sessions(user_id="bad")
     assert err.match(USER_NOT_FOUND_REGEX)
+
+
+@pytest.mark.asyncio
+async def test_a_user_logout_session(
+    admin: KeycloakAdmin, oid_with_credentials: tuple[KeycloakOpenID, str, str]
+) -> None:
+    """
+    Test logging out a single user session.
+
+    :param admin: Keycloak Admin client
+    :type admin: KeycloakAdmin
+    :param oid_with_credentials: Keycloak OpenID client with pre-configured user credentials
+    :type oid_with_credentials: Tuple[KeycloakOpenID, str, str]
+    """
+    oid, username, password = oid_with_credentials
+
+    # Create a session by logging the user in
+    token = oid.token(username, password)
+    user_id = oid.decode_token(token=token["access_token"])["sub"]
+
+    sessions = await admin.a_get_sessions(user_id=user_id)
+    assert len(sessions) >= 1
+    session_id = sessions[0]["id"]
+
+    # Logging out a session that does not belong to the user is rejected locally
+    with pytest.raises(KeycloakDeleteError):
+        await admin.a_user_logout_session(user_id=user_id, session_id="non-existent-session")
+
+    # Skipping the validation (is_offline) lets the server reject an unknown session
+    with pytest.raises(KeycloakDeleteError):
+        await admin.a_user_logout_session(
+            user_id=user_id, session_id="non-existent-session", is_offline=True
+        )
+
+    # Log out only the specific session
+    res = await admin.a_user_logout_session(user_id=user_id, session_id=session_id)
+    assert res == {}
+
+    # The targeted session is gone
+    sessions = await admin.a_get_sessions(user_id=user_id)
+    assert session_id not in {session["id"] for session in sessions}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Add user_logout_session and a_user_logout_session to KeycloakAdmin to log out a single user session, complementing user_logout which terminates all of a user's sessions. The methods validate that the session belongs to the user (for online sessions) and support removing offline sessions via is_offline.

Includes sync + async tests and a docs example; verified against Keycloak 26.0.