### PR TITLE
Do not modify ConnectionManager headers for each request

### DIFF
--- a/src/keycloak/connection.py
+++ b/src/keycloak/connection.py
@@ -252,7 +252,7 @@ class ConnectionManager:
         self._pool_maxsize = value
 
     @property
-    def headers(self) -> dict | None:
+    def headers(self) -> dict:
         """
         Return header request to the server.
 
@@ -274,7 +274,7 @@ class ConnectionManager:
         :returns: If the header parameters exist, return its value.
         :rtype: str
         """
-        return (self.headers or {}).get(key)
+        return self.headers.get(key)
 
     def clean_headers(self) -> None:
         """Clear header parameters."""
@@ -300,9 +300,6 @@ class ConnectionManager:
         :param value: Value to be added.
         :type value: str
         """
-        if self.headers is None:
-            self.headers = {}
-
         self.headers[key] = value
 
     def del_param_headers(self, key: str) -> None:
@@ -312,12 +309,14 @@ class ConnectionManager:
         :param key: Key of the header parameters.
         :type key: str
         """
-        if self.headers is None:
-            return
-
         self.headers.pop(key, None)
 
-    def raw_get(self, path: str, **kwargs: Any) -> Response:  # noqa: ANN401
+    def raw_get(
+        self,
+        path: str,
+        headers: dict[str, str] | None = None,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> Response:
         """
         Submit get request to the path.
 
@@ -336,7 +335,7 @@ class ConnectionManager:
             return self._s.get(
                 urljoin(self.base_url, path),
                 params=kwargs,
-                headers=self.headers,
+                headers=self.headers | (headers or {}),
                 timeout=self.timeout,
                 verify=self.verify,
                 cert=self.cert,
@@ -345,7 +344,13 @@ class ConnectionManager:
             msg = "Can't connect to server"
             raise KeycloakConnectionError(msg) from e
 
-    def raw_post(self, path: str, data: dict | str | MultipartEncoder, **kwargs: Any) -> Response:  # noqa: ANN401
+    def raw_post(
+        self,
+        path: str,
+        data: dict | str | MultipartEncoder,
+        headers: dict[str, str] | None = None,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> Response:
         """
         Submit post request to the path.
 
@@ -367,7 +372,7 @@ class ConnectionManager:
                 urljoin(self.base_url, path),
                 params=kwargs,
                 data=data,
-                headers=self.headers,
+                headers=self.headers | (headers or {}),
                 timeout=self.timeout,
                 verify=self.verify,
                 cert=self.cert,
@@ -376,7 +381,13 @@ class ConnectionManager:
             msg = "Can't connect to server"
             raise KeycloakConnectionError(msg) from e
 
-    def raw_put(self, path: str, data: dict | str | MultipartEncoder, **kwargs: Any) -> Response:  # noqa: ANN401
+    def raw_put(
+        self,
+        path: str,
+        data: dict | str | MultipartEncoder,
+        headers: dict[str, str] | None = None,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> Response:
         """
         Submit put request to the path.
 
@@ -399,7 +410,7 @@ class ConnectionManager:
                 urljoin(self.base_url, path),
                 params=kwargs,
                 data=data,
-                headers=self.headers,
+                headers=self.headers | (headers or {}),
                 timeout=self.timeout,
                 verify=self.verify,
                 cert=self.cert,
@@ -408,7 +419,13 @@ class ConnectionManager:
             msg = "Can't connect to server"
             raise KeycloakConnectionError(msg) from e
 
-    def raw_delete(self, path: str, data: dict | None = None, **kwargs: Any) -> Response:  # noqa: ANN401
+    def raw_delete(
+        self,
+        path: str,
+        data: dict | None = None,
+        headers: dict[str, str] | None = None,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> Response:
         """
         Submit delete request to the path.
 
@@ -431,7 +448,7 @@ class ConnectionManager:
                 urljoin(self.base_url, path),
                 params=kwargs,
                 data=data or {},
-                headers=self.headers,
+                headers=self.headers | (headers or {}),
                 timeout=self.timeout,
                 verify=self.verify,
                 cert=self.cert,
@@ -440,7 +457,12 @@ class ConnectionManager:
             msg = "Can't connect to server"
             raise KeycloakConnectionError(msg) from e
 
-    async def a_raw_get(self, path: str, **kwargs: Any) -> AsyncResponse:  # noqa: ANN401
+    async def a_raw_get(
+        self,
+        path: str,
+        headers: dict[str, str] | None = None,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> AsyncResponse:
         """
         Submit get request to the path.
 
@@ -460,7 +482,7 @@ class ConnectionManager:
             return await self.async_s.get(
                 urljoin(self.base_url, path),
                 params=self._filter_query_params(kwargs),
-                headers=self.headers,
+                headers=self.headers | (headers or {}),
                 timeout=self.timeout,
             )
         except Exception as e:
@@ -471,6 +493,7 @@ class ConnectionManager:
         self,
         path: str,
         data: dict | str | MultipartEncoder,
+        headers: dict[str, str] | None = None,
         **kwargs: Any,  # noqa: ANN401
     ) -> AsyncResponse:
         """
@@ -496,7 +519,7 @@ class ConnectionManager:
                 url=urljoin(self.base_url, path),
                 params=self._filter_query_params(kwargs),
                 **self._prepare_httpx_request_content(data),
-                headers=self.headers,
+                headers=self.headers | (headers or {}),
                 timeout=self.timeout,
             )
         except Exception as e:
@@ -507,6 +530,7 @@ class ConnectionManager:
         self,
         path: str,
         data: dict | str | MultipartEncoder,
+        headers: dict[str, str] | None = None,
         **kwargs: Any,  # noqa: ANN401
     ) -> AsyncResponse:
         """
@@ -531,7 +555,7 @@ class ConnectionManager:
                 urljoin(self.base_url, path),
                 params=self._filter_query_params(kwargs),
                 **self._prepare_httpx_request_content(data),
-                headers=self.headers,
+                headers=self.headers | (headers or {}),
                 timeout=self.timeout,
             )
         except Exception as e:
@@ -542,6 +566,7 @@ class ConnectionManager:
         self,
         path: str,
         data: dict | None = None,
+        headers: dict[str, str] | None = None,
         **kwargs: Any,  # noqa: ANN401
     ) -> AsyncResponse:
         """
@@ -567,7 +592,7 @@ class ConnectionManager:
                 url=urljoin(self.base_url, path),
                 **self._prepare_httpx_request_content(data or {}),
                 params=self._filter_query_params(kwargs),
-                headers=self.headers,
+                headers=self.headers | (headers or {}),
                 timeout=self.timeout,
             )
         except Exception as e:

--- a/src/keycloak/keycloak_openid.py
+++ b/src/keycloak/keycloak_openid.py
@@ -394,13 +394,12 @@ class KeycloakOpenID:
             payload["totp"] = totp
 
         payload = self._add_secret_key(payload)
-        content_type = (self.connection.headers or {}).get("Content-Type")
-        self.connection.add_param_headers("Content-Type", "application/x-www-form-urlencoded")
-        data_raw = self.connection.raw_post(URL_TOKEN.format(**params_path), data=payload)
-        (
-            self.connection.add_param_headers("Content-Type", content_type)
-            if content_type
-            else self.connection.del_param_headers("Content-Type")
+        data_raw = self.connection.raw_post(
+            URL_TOKEN.format(**params_path),
+            data=payload,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
         )
         res = raise_error_from_response(data_raw, KeycloakPostError)
         if not isinstance(res, dict):
@@ -437,13 +436,12 @@ class KeycloakOpenID:
             "refresh_token": refresh_token,
         }
         payload = self._add_secret_key(payload)
-        content_type = (self.connection.headers or {}).get("Content-Type")
-        self.connection.add_param_headers("Content-Type", "application/x-www-form-urlencoded")
-        data_raw = self.connection.raw_post(URL_TOKEN.format(**params_path), data=payload)
-        (
-            self.connection.add_param_headers("Content-Type", content_type)
-            if content_type
-            else self.connection.del_param_headers("Content-Type")
+        data_raw = self.connection.raw_post(
+            URL_TOKEN.format(**params_path),
+            data=payload,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
         )
         res = raise_error_from_response(data_raw, KeycloakPostError)
         if not isinstance(res, dict):
@@ -506,13 +504,12 @@ class KeycloakOpenID:
             "scope": scope,
         }
         payload = self._add_secret_key(payload)
-        content_type = (self.connection.headers or {}).get("Content-Type")
-        self.connection.add_param_headers("Content-Type", "application/x-www-form-urlencoded")
-        data_raw = self.connection.raw_post(URL_TOKEN.format(**params_path), data=payload)
-        (
-            self.connection.add_param_headers("Content-Type", content_type)
-            if content_type
-            else self.connection.del_param_headers("Content-Type")
+        data_raw = self.connection.raw_post(
+            URL_TOKEN.format(**params_path),
+            data=payload,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
         )
         res = raise_error_from_response(data_raw, KeycloakPostError)
         if not isinstance(res, dict):
@@ -538,14 +535,10 @@ class KeycloakOpenID:
         :returns: Userinfo object
         :rtype: dict | bytes
         """
-        orig_bearer = (self.connection.headers or {}).get("Authorization")
-        self.connection.add_param_headers("Authorization", "Bearer " + token)
         params_path = {"realm-name": self.realm_name}
-        data_raw = self.connection.raw_get(URL_USERINFO.format(**params_path))
-        (
-            self.connection.add_param_headers("Authorization", orig_bearer)
-            if orig_bearer is not None
-            else self.connection.del_param_headers("Authorization")
+        data_raw = self.connection.raw_get(
+            URL_USERINFO.format(**params_path),
+            headers={"Authorization": "Bearer " + token},
         )
         res = raise_error_from_response(data_raw, KeycloakGetError)
         if not isinstance(res, (dict, bytes)):
@@ -647,14 +640,10 @@ class KeycloakOpenID:
         :returns: Entitlements
         :rtype: dict
         """
-        orig_bearer = (self.connection.headers or {}).get("Authorization")
-        self.connection.add_param_headers("Authorization", "Bearer " + token)
         params_path = {"realm-name": self.realm_name, "resource-server-id": resource_server_id}
-        data_raw = self.connection.raw_get(URL_ENTITLEMENT.format(**params_path))
-        (
-            self.connection.add_param_headers("Authorization", orig_bearer)
-            if orig_bearer is not None
-            else self.connection.del_param_headers("Authorization")
+        data_raw = self.connection.raw_get(
+            URL_ENTITLEMENT.format(**params_path),
+            headers={"Authorization": "Bearer " + token},
         )
 
         if data_raw.status_code in {HTTP_NOT_FOUND, HTTP_NOT_ALLOWED}:
@@ -705,27 +694,21 @@ class KeycloakOpenID:
         params_path = {"realm-name": self.realm_name}
         payload = {"client_id": self.client_id, "token": token}
 
-        bearer_changed = False
-        orig_bearer = None
+        headers = {}
         if token_type_hint == "requesting_party_token":  # noqa: S105
             if rpt:
                 payload.update({"token": rpt, "token_type_hint": token_type_hint})
-                orig_bearer = (self.connection.headers or {}).get("Authorization")
-                self.connection.add_param_headers("Authorization", "Bearer " + token)
-                bearer_changed = True
+                headers = {"Authorization": "Bearer " + token}
             else:
                 msg = "Can't find RPT"
                 raise KeycloakRPTNotFound(msg)
 
         payload = self._add_secret_key(payload)
-
-        data_raw = self.connection.raw_post(URL_INTROSPECT.format(**params_path), data=payload)
-        if bearer_changed:
-            (
-                self.connection.add_param_headers("Authorization", orig_bearer)
-                if orig_bearer is not None
-                else self.connection.del_param_headers("Authorization")
-            )
+        data_raw = self.connection.raw_post(
+            URL_INTROSPECT.format(**params_path),
+            data=payload,
+            headers=headers,
+        )
 
         res = raise_error_from_response(data_raw, KeycloakPostError)
         if not isinstance(res, dict):
@@ -933,20 +916,13 @@ class KeycloakOpenID:
             **extra_payload,
         }
 
-        orig_bearer = (self.connection.headers or {}).get("Authorization")
-        self.connection.add_param_headers("Authorization", "Bearer " + token)
-        content_type = (self.connection.headers or {}).get("Content-Type")
-        self.connection.add_param_headers("Content-Type", "application/x-www-form-urlencoded")
-        data_raw = self.connection.raw_post(URL_TOKEN.format(**params_path), data=payload)
-        (
-            self.connection.add_param_headers("Content-Type", content_type)
-            if content_type
-            else self.connection.del_param_headers("Content-Type")
-        )
-        (
-            self.connection.add_param_headers("Authorization", orig_bearer)
-            if orig_bearer is not None
-            else self.connection.del_param_headers("Authorization")
+        data_raw = self.connection.raw_post(
+            URL_TOKEN.format(**params_path),
+            data=payload,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Authorization": "Bearer " + token,
+            },
         )
         res = raise_error_from_response(data_raw, KeycloakPostError)
         if not isinstance(res, list):
@@ -1021,23 +997,13 @@ class KeycloakOpenID:
         :rtype: dict
         """
         params_path = {"realm-name": self.realm_name}
-        orig_bearer = (self.connection.headers or {}).get("Authorization")
-        self.connection.add_param_headers("Authorization", "Bearer " + token)
-        orig_content_type = (self.connection.headers or {}).get("Content-Type")
-        self.connection.add_param_headers("Content-Type", "application/json")
         data_raw = self.connection.raw_post(
             URL_CLIENT_REGISTRATION.format(**params_path),
             data=json.dumps(payload),
-        )
-        (
-            self.connection.add_param_headers("Authorization", orig_bearer)
-            if orig_bearer is not None
-            else self.connection.del_param_headers("Authorization")
-        )
-        (
-            self.connection.add_param_headers("Content-Type", orig_content_type)
-            if orig_content_type is not None
-            else self.connection.del_param_headers("Content-Type")
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": "Bearer " + token,
+            },
         )
         res = raise_error_from_response(data_raw, KeycloakPostError)
         if not isinstance(res, dict):
@@ -1102,10 +1068,6 @@ class KeycloakOpenID:
         :rtype: bytes
         """
         params_path = {"realm-name": self.realm_name, "client-id": client_id}
-        orig_bearer = (self.connection.headers or {}).get("Authorization")
-        self.connection.add_param_headers("Authorization", "Bearer " + token)
-        orig_content_type = (self.connection.headers or {}).get("Content-Type")
-        self.connection.add_param_headers("Content-Type", "application/json")
 
         # Keycloak complains if the clientId is not set in the payload
         if "clientId" not in payload:
@@ -1114,16 +1076,10 @@ class KeycloakOpenID:
         data_raw = self.connection.raw_put(
             URL_CLIENT_UPDATE.format(**params_path),
             data=json.dumps(payload),
-        )
-        (
-            self.connection.add_param_headers("Authorization", orig_bearer)
-            if orig_bearer is not None
-            else self.connection.del_param_headers("Authorization")
-        )
-        (
-            self.connection.add_param_headers("Content-Type", orig_content_type)
-            if orig_content_type is not None
-            else self.connection.del_param_headers("Content-Type")
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": "Bearer " + token,
+            },
         )
         res = raise_error_from_response(data_raw, KeycloakPutError)
         if not isinstance(res, dict):
@@ -1282,13 +1238,12 @@ class KeycloakOpenID:
             payload["totp"] = totp
 
         payload = self._add_secret_key(payload)
-        content_type = (self.connection.headers or {}).get("Content-Type")
-        self.connection.add_param_headers("Content-Type", "application/x-www-form-urlencoded")
-        data_raw = await self.connection.a_raw_post(URL_TOKEN.format(**params_path), data=payload)
-        (
-            self.connection.add_param_headers("Content-Type", content_type)
-            if content_type
-            else self.connection.del_param_headers("Content-Type")
+        data_raw = await self.connection.a_raw_post(
+            URL_TOKEN.format(**params_path),
+            data=payload,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
         )
         res = raise_error_from_response(data_raw, KeycloakPostError)
         if not isinstance(res, dict):
@@ -1325,13 +1280,12 @@ class KeycloakOpenID:
             "refresh_token": refresh_token,
         }
         payload = self._add_secret_key(payload)
-        content_type = (self.connection.headers or {}).get("Content-Type")
-        self.connection.add_param_headers("Content-Type", "application/x-www-form-urlencoded")
-        data_raw = await self.connection.a_raw_post(URL_TOKEN.format(**params_path), data=payload)
-        (
-            self.connection.add_param_headers("Content-Type", content_type)
-            if content_type
-            else self.connection.del_param_headers("Content-Type")
+        data_raw = await self.connection.a_raw_post(
+            URL_TOKEN.format(**params_path),
+            data=payload,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
         )
         res = raise_error_from_response(data_raw, KeycloakPostError)
         if not isinstance(res, dict):
@@ -1393,13 +1347,12 @@ class KeycloakOpenID:
             "scope": scope,
         }
         payload = self._add_secret_key(payload)
-        content_type = (self.connection.headers or {}).get("Content-Type")
-        self.connection.add_param_headers("Content-Type", "application/x-www-form-urlencoded")
-        data_raw = await self.connection.a_raw_post(URL_TOKEN.format(**params_path), data=payload)
-        (
-            self.connection.add_param_headers("Content-Type", content_type)
-            if content_type
-            else self.connection.del_param_headers("Content-Type")
+        data_raw = await self.connection.a_raw_post(
+            URL_TOKEN.format(**params_path),
+            data=payload,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
         )
         res = raise_error_from_response(data_raw, KeycloakPostError)
         if not isinstance(res, dict):
@@ -1425,14 +1378,10 @@ class KeycloakOpenID:
         :returns: Userinfo object
         :rtype: dict | bytes
         """
-        orig_bearer = (self.connection.headers or {}).get("Authorization")
-        self.connection.add_param_headers("Authorization", "Bearer " + token)
         params_path = {"realm-name": self.realm_name}
-        data_raw = await self.connection.a_raw_get(URL_USERINFO.format(**params_path))
-        (
-            self.connection.add_param_headers("Authorization", orig_bearer)
-            if orig_bearer is not None
-            else self.connection.del_param_headers("Authorization")
+        data_raw = await self.connection.a_raw_get(
+            URL_USERINFO.format(**params_path),
+            headers={"Authorization": "Bearer " + token},
         )
         res = raise_error_from_response(data_raw, KeycloakGetError)
         if not isinstance(res, (dict, bytes)):
@@ -1534,14 +1483,10 @@ class KeycloakOpenID:
         :returns: Entitlements
         :rtype: dict
         """
-        orig_bearer = (self.connection.headers or {}).get("Authorization")
-        self.connection.add_param_headers("Authorization", "Bearer " + token)
         params_path = {"realm-name": self.realm_name, "resource-server-id": resource_server_id}
-        data_raw = await self.connection.a_raw_get(URL_ENTITLEMENT.format(**params_path))
-        (
-            self.connection.add_param_headers("Authorization", orig_bearer)
-            if orig_bearer is not None
-            else self.connection.del_param_headers("Authorization")
+        data_raw = await self.connection.a_raw_get(
+            URL_ENTITLEMENT.format(**params_path),
+            headers={"Authorization": "Bearer " + token},
         )
 
         if data_raw.status_code in [HTTP_NOT_FOUND, HTTP_NOT_ALLOWED]:
@@ -1593,14 +1538,11 @@ class KeycloakOpenID:
         params_path = {"realm-name": self.realm_name}
         payload = {"client_id": self.client_id, "token": token}
 
-        orig_bearer = None
-        bearer_changed = False
+        headers = {}
         if token_type_hint == "requesting_party_token":  # noqa: S105
             if rpt:
                 payload.update({"token": rpt, "token_type_hint": token_type_hint})
-                orig_bearer = (self.connection.headers or {}).get("Authorization")
-                self.connection.add_param_headers("Authorization", "Bearer " + token)
-                bearer_changed = True
+                headers = {"Authorization": "Bearer " + token}
             else:
                 msg = "Can't find RPT."
                 raise KeycloakRPTNotFound(msg)
@@ -1610,13 +1552,8 @@ class KeycloakOpenID:
         data_raw = await self.connection.a_raw_post(
             URL_INTROSPECT.format(**params_path),
             data=payload,
+            headers=headers,
         )
-        if bearer_changed:
-            (
-                self.connection.add_param_headers("Authorization", orig_bearer)
-                if orig_bearer is not None
-                else self.connection.del_param_headers("Authorization")
-            )
         res = raise_error_from_response(data_raw, KeycloakPostError)
         if not isinstance(res, dict):
             msg = (
@@ -1794,20 +1731,13 @@ class KeycloakOpenID:
             **extra_payload,
         }
 
-        orig_bearer = (self.connection.headers or {}).get("Authorization")
-        self.connection.add_param_headers("Authorization", "Bearer " + token)
-        content_type = (self.connection.headers or {}).get("Content-Type")
-        self.connection.add_param_headers("Content-Type", "application/x-www-form-urlencoded")
-        data_raw = await self.connection.a_raw_post(URL_TOKEN.format(**params_path), data=payload)
-        (
-            self.connection.add_param_headers("Content-Type", content_type)
-            if content_type
-            else self.connection.del_param_headers("Content-Type")
-        )
-        (
-            self.connection.add_param_headers("Authorization", orig_bearer)
-            if orig_bearer is not None
-            else self.connection.del_param_headers("Authorization")
+        data_raw = await self.connection.a_raw_post(
+            URL_TOKEN.format(**params_path),
+            data=payload,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Authorization": "Bearer " + token,
+            },
         )
         res = raise_error_from_response(data_raw, KeycloakPostError)
         if not isinstance(res, list):
@@ -1882,23 +1812,13 @@ class KeycloakOpenID:
         :rtype: dict
         """
         params_path = {"realm-name": self.realm_name}
-        orig_bearer = (self.connection.headers or {}).get("Authorization")
-        self.connection.add_param_headers("Authorization", "Bearer " + token)
-        orig_content_type = (self.connection.headers or {}).get("Content-Type")
-        self.connection.add_param_headers("Content-Type", "application/json")
         data_raw = await self.connection.a_raw_post(
             URL_CLIENT_REGISTRATION.format(**params_path),
             data=json.dumps(payload),
-        )
-        (
-            self.connection.add_param_headers("Authorization", orig_bearer)
-            if orig_bearer is not None
-            else self.connection.del_param_headers("Authorization")
-        )
-        (
-            self.connection.add_param_headers("Content-Type", orig_content_type)
-            if orig_content_type is not None
-            else self.connection.del_param_headers("Content-Type")
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": "Bearer " + token,
+            },
         )
         res = raise_error_from_response(data_raw, KeycloakPostError)
         if not isinstance(res, dict):
@@ -1963,10 +1883,6 @@ class KeycloakOpenID:
         :rtype: dict
         """
         params_path = {"realm-name": self.realm_name, "client-id": client_id}
-        orig_bearer = (self.connection.headers or {}).get("Authorization")
-        self.connection.add_param_headers("Authorization", "Bearer " + token)
-        orig_content_type = (self.connection.headers or {}).get("Content-Type")
-        self.connection.add_param_headers("Content-Type", "application/json")
 
         # Keycloak complains if the clientId is not set in the payload
         if "clientId" not in payload:
@@ -1975,16 +1891,10 @@ class KeycloakOpenID:
         data_raw = await self.connection.a_raw_put(
             URL_CLIENT_UPDATE.format(**params_path),
             data=json.dumps(payload),
-        )
-        (
-            self.connection.add_param_headers("Authorization", orig_bearer)
-            if orig_bearer is not None
-            else self.connection.del_param_headers("Authorization")
-        )
-        (
-            self.connection.add_param_headers("Content-Type", orig_content_type)
-            if orig_content_type is not None
-            else self.connection.del_param_headers("Content-Type")
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": "Bearer " + token,
+            },
         )
         res = raise_error_from_response(data_raw, KeycloakPutError)
         if not isinstance(res, dict):

--- a/src/keycloak/keycloak_uma.py
+++ b/src/keycloak/keycloak_uma.py
@@ -33,7 +33,6 @@ import json
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote_plus
 
-from .connection import ConnectionManager
 from .exceptions import (
     HTTP_CREATED,
     HTTP_NO_CONTENT,
@@ -461,18 +460,14 @@ class KeycloakUMA:
             )
             raise AttributeError(msg)
 
-        connection = ConnectionManager(
-            base_url=self.connection.base_url,
-            timeout=self.connection.timeout,
-            verify=self.connection.verify,
-            proxies=self.connection.proxies,
-            cert=self.connection.cert,
-            max_retries=self.connection.max_retries,
-            pool_maxsize=self.connection.pool_maxsize,
+        data_raw = self.connection.raw_post(
+            self.uma_well_known["token_endpoint"],
+            data=payload,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Authorization": "Bearer " + token,
+            },
         )
-        connection.add_param_headers("Authorization", "Bearer " + token)
-        connection.add_param_headers("Content-Type", "application/x-www-form-urlencoded")
-        data_raw = connection.raw_post(self.uma_well_known["token_endpoint"], data=payload)
         try:
             data = raise_error_from_response(data_raw, KeycloakPostError)
         except KeycloakPostError:
@@ -954,20 +949,13 @@ class KeycloakUMA:
             )
             raise AttributeError(msg)
 
-        connection = ConnectionManager(
-            base_url=self.connection.base_url,
-            timeout=self.connection.timeout,
-            verify=self.connection.verify,
-            proxies=self.connection.proxies,
-            cert=self.connection.cert,
-            max_retries=self.connection.max_retries,
-            pool_maxsize=self.connection.pool_maxsize,
-        )
-        connection.add_param_headers("Authorization", "Bearer " + token)
-        connection.add_param_headers("Content-Type", "application/x-www-form-urlencoded")
-        data_raw = await connection.a_raw_post(
+        data_raw = await self.connection.a_raw_post(
             (await self.a_uma_well_known)["token_endpoint"],
             data=payload,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Authorization": "Bearer " + token,
+            },
         )
         try:
             data = raise_error_from_response(data_raw, KeycloakPostError)

--- a/src/keycloak/openid_connection.py
+++ b/src/keycloak/openid_connection.py
@@ -332,7 +332,7 @@ class KeycloakOpenIDConnection(ConnectionManager):
     @custom_headers.setter
     def custom_headers(self, value: dict | None) -> None:
         self._custom_headers = value
-        if self.custom_headers is not None and self.headers is not None:
+        if self.custom_headers:
             # merge custom headers to main headers
             self.headers.update(self.custom_headers)
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -19,6 +19,9 @@ def test_connection_proxy() -> None:
 
 def test_headers() -> None:
     """Test headers manipulation."""
+    cm = ConnectionManager(base_url="http://test.test")
+    assert cm.headers == {}
+
     cm = ConnectionManager(base_url="http://test.test", headers={"H": "A"})
     assert cm.param_headers(key="H") == "A"
     assert cm.param_headers(key="A") is None


### PR DESCRIPTION
ConnectionManager is designed to be created as a shared object (according to name and `max_pool_size` param).

But calling `add_param_headers` / `del_param_headers` will modify headers for _all_ connections send, not just next one. There are a lot of calls like that within `KeycloakOpenID` class methods, so it is not safe to use these methods from parallel asyncio tasks.

Also if request method raised an exception, header cleanup methods are never called, potentially breaking the entire ConnectionManager.

Instead of modifying shared `headers` object, merge connection headers with per-request headers, making a local dict copy just before request is sent.