### PR TITLE
ci: rename lint workflow to ci

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -2,7 +2,7 @@ name: Bump version
 
 on:
   workflow_run:
-    workflows: ["Lint"]
+    workflows: ["CI"]
     branches: [master]
     types:
       - completed

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Lint
+name: CI
 
 on:
   push:
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.13
+      - name: Set up Python 3.14
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
@@ -37,7 +37,7 @@ jobs:
       - check-linting
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.13
+      - name: Set up Python 3.14
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
@@ -88,7 +88,7 @@ jobs:
       - check-docs
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.13
+      - name: Set up Python 3.14
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
-      - name: Set up Python 3.13
+      - name: Set up Python 3.14
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"


### PR DESCRIPTION
It's a bit misleading/confusing to have this all-in-one CI flow called linting, it also runs tests, validates commit messages, builds documentation, and creates package artifacts.


<img width="488" height="65" alt="image" src="https://github.com/user-attachments/assets/f0c6d902-be59-4768-b8a4-3c621960d1ba" />
